### PR TITLE
Add ImageNet pre-trained weights under `pretrained` feature flag

### DIFF
--- a/resnet-burn/Cargo.toml
+++ b/resnet-burn/Cargo.toml
@@ -21,4 +21,7 @@ serde = { version = "1.0.192", default-features = false, features = [
 ] } # alloc is for no_std, derive is needed
 
 [dev-dependencies]
+burn = { git = "https://github.com/tracel-ai/burn.git", rev = "9a2cbadd41161c8aac142bbcb9c2ceaf5ffd6edd", features = [
+    "ndarray",
+] }
 image = { version = "0.24.7", features = ["png", "jpeg"] }

--- a/resnet-burn/Cargo.toml
+++ b/resnet-burn/Cargo.toml
@@ -6,17 +6,19 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["burn/default"]
-
+default = []
+std = []
+pretrained = ["burn/network", "std", "dep:dirs"]
 
 [dependencies]
 # Note: default-features = false is needed to disable std
-burn = { git = "https://github.com/tracel-ai/burn.git", rev = "75cb5b6d5633c1c6092cf5046419da75e7f74b11", default-features = false }
+burn = { git = "https://github.com/tracel-ai/burn.git", rev = "9a2cbadd41161c8aac142bbcb9c2ceaf5ffd6edd", default-features = false }
+burn-import = { git = "https://github.com/tracel-ai/burn.git", rev = "9a2cbadd41161c8aac142bbcb9c2ceaf5ffd6edd" }
+dirs = { version = "5.0.1", optional = true }
 serde = { version = "1.0.192", default-features = false, features = [
     "derive",
     "alloc",
 ] } # alloc is for no_std, derive is needed
 
 [dev-dependencies]
-burn-import = { git = "https://github.com/tracel-ai/burn.git", rev = "75cb5b6d5633c1c6092cf5046419da75e7f74b11"}
 image = { version = "0.24.7", features = ["png", "jpeg"] }

--- a/resnet-burn/README.md
+++ b/resnet-burn/README.md
@@ -17,17 +17,23 @@ Add this to your `Cargo.toml`:
 resnet-burn = { git = "https://github.com/burn-rs/models", package = "resnet-burn", default-features = false }
 ```
 
+If you want to get the pre-trained ImageNet weights, enable the `pretrained` feature flag.
+
+```toml
+[dependencies]
+resnet-burn = { git = "https://github.com/burn-rs/models", package = "resnet-burn", features = ["pretrained"] }
+```
+
+**Important:** this feature requires `std`.
+
 ### Example Usage
 
-The [inference example](examples/inference.rs) initializes a ResNet-18 with the `NdArray` backend,
-imports the ImageNet pre-trained weights from
-[`torchvision`](https://download.pytorch.org/models/resnet18-f37072fd.pth) and performs inference on
-the provided input image.
+The [inference example](examples/inference.rs) initializes a ResNet-18 from the ImageNet
+[pre-trained weights](https://pytorch.org/vision/stable/models/generated/torchvision.models.resnet18.html#torchvision.models.ResNet18_Weights)
+with the `NdArray` backend and performs inference on the provided input image.
 
-After downloading the
-[pre-trained weights](https://download.pytorch.org/models/resnet18-f37072fd.pth) to the current
-directory, you can run the example with the following command:
+You can run the example with the following command:
 
 ```sh
-cargo run --release --example inference samples/dog.jpg
+cargo run --release --features pretrained --example inference samples/dog.jpg
 ```

--- a/resnet-burn/examples/inference.rs
+++ b/resnet-burn/examples/inference.rs
@@ -31,7 +31,7 @@ pub fn main() {
     let device = Default::default();
     let model: ResNet<NdArray, _> =
         ResNet::resnet18_pretrained(weights::ResNet18::ImageNet1kV1, &device)
-            .map_err(|err| format!("Failed to load pre-traind weightts.\nError: {err}"))
+            .map_err(|err| format!("Failed to load pre-trained weights.\nError: {err}"))
             .unwrap();
 
     // Save the model to a supported format and load it back

--- a/resnet-burn/src/lib.rs
+++ b/resnet-burn/src/lib.rs
@@ -1,3 +1,3 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 pub mod model;
 extern crate alloc;

--- a/resnet-burn/src/model/block.rs
+++ b/resnet-burn/src/model/block.rs
@@ -1,3 +1,4 @@
+use core::f64::consts::SQRT_2;
 use core::marker::PhantomData;
 
 use alloc::vec::Vec;
@@ -12,7 +13,6 @@ use burn::{
 };
 
 pub trait ResidualBlock<B: Backend> {
-    fn new(in_channels: usize, out_channels: usize, stride: usize, device: &Device<B>) -> Self;
     fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4>;
 }
 
@@ -29,49 +29,6 @@ pub struct BasicBlock<B: Backend> {
 }
 
 impl<B: Backend> ResidualBlock<B> for BasicBlock<B> {
-    fn new(in_channels: usize, out_channels: usize, stride: usize, device: &Device<B>) -> Self {
-        // conv3x3
-        let conv1 = Conv2dConfig::new([in_channels, out_channels], [3, 3])
-            .with_stride([stride, stride])
-            .with_padding(PaddingConfig2d::Explicit(1, 1))
-            .with_bias(false)
-            .with_initializer(Initializer::KaimingNormal {
-                gain: f64::sqrt(2.0), // recommended value for ReLU
-                fan_out_only: true,
-            })
-            .init(device);
-        let bn1 = BatchNormConfig::new(out_channels).init(device);
-        let relu = ReLU::new();
-        // conv3x3
-        let conv2 = Conv2dConfig::new([out_channels, out_channels], [3, 3])
-            .with_stride([1, 1])
-            .with_padding(PaddingConfig2d::Explicit(1, 1))
-            .with_bias(false)
-            .with_initializer(Initializer::KaimingNormal {
-                gain: f64::sqrt(2.0), // recommended value for ReLU
-                fan_out_only: true,
-            })
-            .init(device);
-        let bn2 = BatchNormConfig::new(out_channels).init(device);
-
-        let downsample = {
-            if in_channels != out_channels {
-                Some(Downsample::new(in_channels, out_channels, stride, device))
-            } else {
-                None
-            }
-        };
-
-        Self {
-            conv1,
-            bn1,
-            relu,
-            conv2,
-            bn2,
-            downsample,
-        }
-    }
-
     fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let identity = input.clone();
 
@@ -95,36 +52,6 @@ impl<B: Backend> ResidualBlock<B> for BasicBlock<B> {
     }
 }
 
-/// Downsample layer applies a 1x1 conv to reduce the resolution (H, W) and adjust the number of channels.
-#[derive(Module, Debug)]
-pub struct Downsample<B: Backend> {
-    conv: Conv2d<B>,
-    bn: BatchNorm<B, 2>,
-}
-
-impl<B: Backend> Downsample<B> {
-    pub fn new(in_channels: usize, out_channels: usize, stride: usize, device: &Device<B>) -> Self {
-        // conv1x1
-        let conv = Conv2dConfig::new([in_channels, out_channels], [1, 1])
-            .with_stride([stride, stride])
-            .with_padding(PaddingConfig2d::Explicit(0, 0))
-            .with_bias(false)
-            .with_initializer(Initializer::KaimingNormal {
-                gain: f64::sqrt(2.0), // recommended value for ReLU
-                fan_out_only: true,
-            })
-            .init(device);
-        let bn = BatchNormConfig::new(out_channels).init(device);
-
-        Self { conv, bn }
-    }
-
-    pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
-        let out = self.conv.forward(input);
-        self.bn.forward(out)
-    }
-}
-
 /// ResNet [bottleneck residual block](https://paperswithcode.com/method/bottleneck-residual-block)
 /// implementation.
 /// Derived from [torchivision.models.resnet.Bottleneck](https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py).
@@ -145,64 +72,6 @@ pub struct Bottleneck<B: Backend> {
 }
 
 impl<B: Backend> ResidualBlock<B> for Bottleneck<B> {
-    fn new(in_channels: usize, out_channels: usize, stride: usize, device: &Device<B>) -> Self {
-        // Intermediate output channels w/ expansion = 4
-        let int_out_channels = out_channels / 4;
-        // conv1x1
-        let conv1 = Conv2dConfig::new([in_channels, int_out_channels], [1, 1])
-            .with_stride([1, 1])
-            .with_padding(PaddingConfig2d::Explicit(0, 0))
-            .with_bias(false)
-            .with_initializer(Initializer::KaimingNormal {
-                gain: f64::sqrt(2.0), // recommended value for ReLU
-                fan_out_only: true,
-            })
-            .init(device);
-        let bn1 = BatchNormConfig::new(int_out_channels).init(device);
-        let relu = ReLU::new();
-        // conv3x3
-        let conv2 = Conv2dConfig::new([int_out_channels, int_out_channels], [3, 3])
-            .with_stride([stride, stride])
-            .with_padding(PaddingConfig2d::Explicit(1, 1))
-            .with_bias(false)
-            .with_initializer(Initializer::KaimingNormal {
-                gain: f64::sqrt(2.0), // recommended value for ReLU
-                fan_out_only: true,
-            })
-            .init(device);
-        let bn2 = BatchNormConfig::new(int_out_channels).init(device);
-        // conv1x1
-        let conv3 = Conv2dConfig::new([int_out_channels, out_channels], [1, 1])
-            .with_stride([1, 1])
-            .with_padding(PaddingConfig2d::Explicit(0, 0))
-            .with_bias(false)
-            .with_initializer(Initializer::KaimingNormal {
-                gain: f64::sqrt(2.0), // recommended value for ReLU
-                fan_out_only: true,
-            })
-            .init(device);
-        let bn3 = BatchNormConfig::new(out_channels).init(device);
-
-        let downsample = {
-            if in_channels != out_channels {
-                Some(Downsample::new(in_channels, out_channels, stride, device))
-            } else {
-                None
-            }
-        };
-
-        Self {
-            conv1,
-            bn1,
-            relu,
-            conv2,
-            bn2,
-            conv3,
-            bn3,
-            downsample,
-        }
-    }
-
     fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let identity = input.clone();
 
@@ -229,6 +98,20 @@ impl<B: Backend> ResidualBlock<B> for Bottleneck<B> {
     }
 }
 
+/// Downsample layer applies a 1x1 conv to reduce the resolution (H, W) and adjust the number of channels.
+#[derive(Module, Debug)]
+pub struct Downsample<B: Backend> {
+    conv: Conv2d<B>,
+    bn: BatchNorm<B, 2>,
+}
+
+impl<B: Backend> Downsample<B> {
+    pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
+        let out = self.conv.forward(input);
+        self.bn.forward(out)
+    }
+}
+
 /// Collection of sequential residual blocks.
 #[derive(Module, Debug)]
 pub struct LayerBlock<B: Backend, M> {
@@ -237,36 +120,371 @@ pub struct LayerBlock<B: Backend, M> {
 }
 
 impl<B: Backend, M: ResidualBlock<B>> LayerBlock<B, M> {
-    pub fn new(
-        num_blocks: usize,
-        in_channels: usize,
-        out_channels: usize,
-        stride: usize,
-        device: &Device<B>,
-    ) -> Self {
-        let blocks = (0..num_blocks)
-            .map(|b| {
-                if b == 0 {
-                    // First block uses the specified stride
-                    M::new(in_channels, out_channels, stride, device)
-                } else {
-                    // Other blocks use a stride of 1
-                    M::new(out_channels, out_channels, 1, device)
-                }
-            })
-            .collect();
-
-        Self {
-            blocks,
-            _backend: PhantomData,
-        }
-    }
-
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 4> {
         let mut out = input;
         for block in &self.blocks {
             out = block.forward(out);
         }
         out
+    }
+}
+
+/// [Basic residual block](BasicBlock) configuration.
+struct BasicBlockConfig {
+    conv1: Conv2dConfig,
+    bn1: BatchNormConfig,
+    conv2: Conv2dConfig,
+    bn2: BatchNormConfig,
+    downsample: Option<DownsampleConfig>,
+}
+
+impl BasicBlockConfig {
+    /// Create a new instance of the residual block [config](BasicBlockConfig).
+    fn new(in_channels: usize, out_channels: usize, stride: usize) -> Self {
+        // conv3x3
+        let conv1 = Conv2dConfig::new([in_channels, out_channels], [3, 3])
+            .with_stride([stride, stride])
+            .with_padding(PaddingConfig2d::Explicit(1, 1))
+            .with_bias(false);
+        let bn1 = BatchNormConfig::new(out_channels);
+
+        // conv3x3
+        let conv2 = Conv2dConfig::new([out_channels, out_channels], [3, 3])
+            .with_stride([1, 1])
+            .with_padding(PaddingConfig2d::Explicit(1, 1))
+            .with_bias(false);
+        let bn2 = BatchNormConfig::new(out_channels);
+
+        let downsample = {
+            if in_channels != out_channels {
+                Some(DownsampleConfig::new(in_channels, out_channels, stride))
+            } else {
+                None
+            }
+        };
+
+        Self {
+            conv1,
+            bn1,
+            conv2,
+            bn2,
+            downsample,
+        }
+    }
+
+    /// Initialize a new [basic residual block](BasicBlock) module.
+    fn init<B: Backend>(&self, device: &Device<B>) -> BasicBlock<B> {
+        // Conv initializer
+        let initializer = Initializer::KaimingNormal {
+            gain: SQRT_2, // recommended value for ReLU
+            fan_out_only: true,
+        };
+
+        BasicBlock {
+            conv1: self
+                .conv1
+                .clone()
+                .with_initializer(initializer.clone())
+                .init(device),
+            bn1: self.bn1.init(device),
+            relu: ReLU::new(),
+            conv2: self
+                .conv2
+                .clone()
+                .with_initializer(initializer)
+                .init(device),
+            bn2: self.bn2.init(device),
+            downsample: self.downsample.as_ref().map(|d| d.init(device)),
+        }
+    }
+
+    /// Initialize a new [basic residual block](BasicBlock) module with a [record](BasicBlockRecord).
+    fn init_with<B: Backend>(&self, record: BasicBlockRecord<B>) -> BasicBlock<B> {
+        // println!("Downsample cfg {}", self.downsample.is_none());
+        // println!("Downsample record {}", record.downsample.is_none());
+
+        BasicBlock {
+            conv1: self.conv1.init_with(record.conv1),
+            bn1: self.bn1.init_with(record.bn1),
+            relu: ReLU::new(),
+            conv2: self.conv2.init_with(record.conv2),
+            bn2: self.bn2.init_with(record.bn2),
+            downsample: self.downsample.as_ref().map(|d| {
+                d.init_with(
+                    record
+                        .downsample
+                        .expect("Should initialize downsample block with record."),
+                )
+            }),
+        }
+    }
+}
+
+/// [Bottleneck residual block](Bottleneck) configuration.
+struct BottleneckConfig {
+    conv1: Conv2dConfig,
+    bn1: BatchNormConfig,
+    conv2: Conv2dConfig,
+    bn2: BatchNormConfig,
+    conv3: Conv2dConfig,
+    bn3: BatchNormConfig,
+    downsample: Option<DownsampleConfig>,
+}
+
+impl BottleneckConfig {
+    /// Create a new instance of the bottleneck residual block [config](BottleneckConfig).
+    fn new(in_channels: usize, out_channels: usize, stride: usize) -> Self {
+        // Intermediate output channels w/ expansion = 4
+        let int_out_channels = out_channels / 4;
+        // conv1x1
+        let conv1 = Conv2dConfig::new([in_channels, int_out_channels], [1, 1])
+            .with_stride([1, 1])
+            .with_padding(PaddingConfig2d::Explicit(0, 0))
+            .with_bias(false);
+        let bn1 = BatchNormConfig::new(int_out_channels);
+        // conv3x3
+        let conv2 = Conv2dConfig::new([int_out_channels, int_out_channels], [3, 3])
+            .with_stride([stride, stride])
+            .with_padding(PaddingConfig2d::Explicit(1, 1))
+            .with_bias(false);
+        let bn2 = BatchNormConfig::new(int_out_channels);
+        // conv1x1
+        let conv3 = Conv2dConfig::new([int_out_channels, out_channels], [1, 1])
+            .with_stride([1, 1])
+            .with_padding(PaddingConfig2d::Explicit(0, 0))
+            .with_bias(false);
+        let bn3 = BatchNormConfig::new(out_channels);
+
+        let downsample = {
+            if in_channels != out_channels {
+                Some(DownsampleConfig::new(in_channels, out_channels, stride))
+            } else {
+                None
+            }
+        };
+
+        Self {
+            conv1,
+            bn1,
+            conv2,
+            bn2,
+            conv3,
+            bn3,
+            downsample,
+        }
+    }
+
+    /// Initialize a new [bottleneck residual block](Bottleneck) module.
+    fn init<B: Backend>(&self, device: &Device<B>) -> Bottleneck<B> {
+        // Conv initializer
+        let initializer = Initializer::KaimingNormal {
+            gain: SQRT_2, // recommended value for ReLU
+            fan_out_only: true,
+        };
+
+        Bottleneck {
+            conv1: self
+                .conv1
+                .clone()
+                .with_initializer(initializer.clone())
+                .init(device),
+            bn1: self.bn1.init(device),
+            relu: ReLU::new(),
+            conv2: self
+                .conv2
+                .clone()
+                .with_initializer(initializer.clone())
+                .init(device),
+            bn2: self.bn2.init(device),
+            conv3: self
+                .conv3
+                .clone()
+                .with_initializer(initializer)
+                .init(device),
+            bn3: self.bn3.init(device),
+            downsample: self.downsample.as_ref().map(|d| d.init(device)),
+        }
+    }
+
+    /// Initialize a new [bottleneck residual block](Bottleneck) module with a [record](BottleneckRecord).
+    fn init_with<B: Backend>(&self, record: BottleneckRecord<B>) -> Bottleneck<B> {
+        Bottleneck {
+            conv1: self.conv1.init_with(record.conv1),
+            bn1: self.bn1.init_with(record.bn1),
+            relu: ReLU::new(),
+            conv2: self.conv2.init_with(record.conv2),
+            bn2: self.bn2.init_with(record.bn2),
+            conv3: self.conv3.init_with(record.conv3),
+            bn3: self.bn3.init_with(record.bn3),
+            downsample: self.downsample.as_ref().map(|d| {
+                d.init_with(
+                    record
+                        .downsample
+                        .expect("Should initialize downsample block with record."),
+                )
+            }),
+        }
+    }
+}
+
+/// [Downsample](Downsample) configuration.
+struct DownsampleConfig {
+    conv: Conv2dConfig,
+    bn: BatchNormConfig,
+}
+
+impl DownsampleConfig {
+    /// Create a new instance of the downsample [config](DownsampleConfig).
+    fn new(in_channels: usize, out_channels: usize, stride: usize) -> Self {
+        // conv1x1
+        let conv = Conv2dConfig::new([in_channels, out_channels], [1, 1])
+            .with_stride([stride, stride])
+            .with_padding(PaddingConfig2d::Explicit(0, 0))
+            .with_bias(false);
+        let bn = BatchNormConfig::new(out_channels);
+
+        Self { conv, bn }
+    }
+
+    /// Initialize a new [downsample](Downsample) module.
+    fn init<B: Backend>(&self, device: &B::Device) -> Downsample<B> {
+        // Conv initializer
+        let initializer = Initializer::KaimingNormal {
+            gain: SQRT_2, // recommended value for ReLU
+            fan_out_only: true,
+        };
+
+        Downsample {
+            conv: self.conv.clone().with_initializer(initializer).init(device),
+            bn: self.bn.init(device),
+        }
+    }
+
+    /// Initialize a new [downsample](Downsample) module with a [record](DownsampleRecord).
+    fn init_with<B: Backend>(&self, record: DownsampleRecord<B>) -> Downsample<B> {
+        Downsample {
+            conv: self.conv.init_with(record.conv),
+            bn: self.bn.init_with(record.bn),
+        }
+    }
+}
+
+/// [Residual layer block](LayerBlock) configuration.
+pub struct LayerBlockConfig<M> {
+    num_blocks: usize,
+    in_channels: usize,
+    out_channels: usize,
+    stride: usize,
+    _block: PhantomData<M>,
+}
+
+impl<M> LayerBlockConfig<M> {
+    /// Create a new instance of the layer block [config](LayerBlockConfig).
+    pub fn new(num_blocks: usize, in_channels: usize, out_channels: usize, stride: usize) -> Self {
+        Self {
+            num_blocks,
+            in_channels,
+            out_channels,
+            stride,
+            _block: PhantomData,
+        }
+    }
+}
+
+impl<B: Backend> LayerBlockConfig<BasicBlock<B>> {
+    /// Initialize a new [LayerBlock](LayerBlock) module with [basic residual blocks](BasicBlock).
+    pub fn init(&self, device: &Device<B>) -> LayerBlock<B, BasicBlock<B>> {
+        let blocks = (0..self.num_blocks)
+            .map(|b| {
+                if b == 0 {
+                    // First block uses the specified stride
+                    BasicBlockConfig::new(self.in_channels, self.out_channels, self.stride)
+                        .init(device)
+                } else {
+                    // Other blocks use a stride of 1
+                    BasicBlockConfig::new(self.out_channels, self.out_channels, 1).init(device)
+                }
+            })
+            .collect();
+
+        LayerBlock {
+            blocks,
+            _backend: PhantomData,
+        }
+    }
+
+    /// Initialize a new [LayerBlock](LayerBlock) module with a [record](LayerBlockRecord) for
+    /// [basic residual blocks](BasicBlock).
+    pub fn init_with(
+        &self,
+        record: LayerBlockRecord<B, BasicBlock<B>>,
+    ) -> LayerBlock<B, BasicBlock<B>> {
+        let blocks = (0..self.num_blocks)
+            .zip(record.blocks)
+            .map(|(b, rec)| {
+                if b == 0 {
+                    // First block uses the specified stride
+                    BasicBlockConfig::new(self.in_channels, self.out_channels, self.stride)
+                        .init_with(rec)
+                } else {
+                    // Other blocks use a stride of 1
+                    BasicBlockConfig::new(self.out_channels, self.out_channels, 1).init_with(rec)
+                }
+            })
+            .collect();
+
+        LayerBlock {
+            blocks,
+            _backend: PhantomData,
+        }
+    }
+}
+
+impl<B: Backend> LayerBlockConfig<Bottleneck<B>> {
+    /// Initialize a new [LayerBlock](LayerBlock) module with [bottleneck residual blocks](Bottleneck).
+    pub fn init(&self, device: &Device<B>) -> LayerBlock<B, Bottleneck<B>> {
+        let blocks = (0..self.num_blocks)
+            .map(|b| {
+                if b == 0 {
+                    // First block uses the specified stride
+                    BottleneckConfig::new(self.in_channels, self.out_channels, self.stride)
+                        .init(device)
+                } else {
+                    // Other blocks use a stride of 1
+                    BottleneckConfig::new(self.out_channels, self.out_channels, 1).init(device)
+                }
+            })
+            .collect();
+
+        LayerBlock {
+            blocks,
+            _backend: PhantomData,
+        }
+    }
+
+    /// Initialize a new [LayerBlock](LayerBlock) module with a [record](LayerBlockRecord) for
+    /// [bottleneck residual blocks](Bottleneck).
+    pub fn init_with(
+        &self,
+        record: LayerBlockRecord<B, Bottleneck<B>>,
+    ) -> LayerBlock<B, Bottleneck<B>> {
+        let blocks = (0..self.num_blocks)
+            .zip(record.blocks)
+            .map(|(b, rec)| {
+                if b == 0 {
+                    // First block uses the specified stride
+                    BottleneckConfig::new(self.in_channels, self.out_channels, self.stride)
+                        .init_with(rec)
+                } else {
+                    // Other blocks use a stride of 1
+                    BottleneckConfig::new(self.out_channels, self.out_channels, 1).init_with(rec)
+                }
+            })
+            .collect();
+
+        LayerBlock {
+            blocks,
+            _backend: PhantomData,
+        }
     }
 }

--- a/resnet-burn/src/model/block.rs
+++ b/resnet-burn/src/model/block.rs
@@ -200,9 +200,6 @@ impl BasicBlockConfig {
 
     /// Initialize a new [basic residual block](BasicBlock) module with a [record](BasicBlockRecord).
     fn init_with<B: Backend>(&self, record: BasicBlockRecord<B>) -> BasicBlock<B> {
-        // println!("Downsample cfg {}", self.downsample.is_none());
-        // println!("Downsample record {}", record.downsample.is_none());
-
         BasicBlock {
             conv1: self.conv1.init_with(record.conv1),
             bn1: self.bn1.init_with(record.bn1),

--- a/resnet-burn/src/model/mod.rs
+++ b/resnet-burn/src/model/mod.rs
@@ -1,3 +1,4 @@
 mod block;
 pub mod imagenet;
 pub mod resnet;
+pub mod weights;

--- a/resnet-burn/src/model/resnet.rs
+++ b/resnet-burn/src/model/resnet.rs
@@ -203,7 +203,7 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ) -> Result<Self, RecorderError> {
         let weights = weights.weights();
         let record = Self::load_weights_record(&weights, device)?;
-        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET50_BLOCKS, weights.num_classes, 1)
+        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET50_BLOCKS, weights.num_classes, 4)
             .init_with(record);
 
         Ok(model)
@@ -236,12 +236,12 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     /// A ResNet-101 module with pre-trained weights.
     #[cfg(feature = "pretrained")]
     pub fn resnet101_pretrained(
-        weights: weights::ResNet50,
+        weights: weights::ResNet101,
         device: &Device<B>,
     ) -> Result<Self, RecorderError> {
         let weights = weights.weights();
         let record = Self::load_weights_record(&weights, device)?;
-        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET101_BLOCKS, weights.num_classes, 1)
+        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET101_BLOCKS, weights.num_classes, 4)
             .init_with(record);
 
         Ok(model)
@@ -274,12 +274,12 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     /// A ResNet-152 module with pre-trained weights.
     #[cfg(feature = "pretrained")]
     pub fn resnet152_pretrained(
-        weights: weights::ResNet50,
+        weights: weights::ResNet152,
         device: &Device<B>,
     ) -> Result<Self, RecorderError> {
         let weights = weights.weights();
         let record = Self::load_weights_record(&weights, device)?;
-        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET152_BLOCKS, weights.num_classes, 1)
+        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET152_BLOCKS, weights.num_classes, 4)
             .init_with(record);
 
         Ok(model)

--- a/resnet-burn/src/model/resnet.rs
+++ b/resnet-burn/src/model/resnet.rs
@@ -84,7 +84,7 @@ impl<B: Backend, M: Module<B>> ResNet<B, M> {
             // Map *.downsample.1.* -> *.downsample.bn.*
             .with_key_remap("(.+)\\.downsample\\.1\\.(.+)", "$1.downsample.bn.$2")
             // Map layer[i].[j].* -> layer[i].blocks.[j].*
-            .with_key_remap("(layer[1-4])\\.([0-9])\\.(.+)", "$1.blocks.$2.$3");
+            .with_key_remap("(layer[1-4])\\.([0-9]+)\\.(.+)", "$1.blocks.$2.$3");
         let record = PyTorchFileRecorder::<FullPrecisionSettings>::new().load(load_args, device)?;
 
         Ok(record)

--- a/resnet-burn/src/model/resnet.rs
+++ b/resnet-burn/src/model/resnet.rs
@@ -302,7 +302,7 @@ struct ResNetConfig<B, M> {
 
 impl<B: Backend, M> ResNetConfig<B, M> {
     /// Create a new instance of the ResNet [config](ResNetConfig).
-    pub fn new(blocks: [usize; 4], num_classes: usize, expansion: usize) -> Self {
+    fn new(blocks: [usize; 4], num_classes: usize, expansion: usize) -> Self {
         // `new()` is private but still check just in case...
         assert!(
             expansion == 1 || expansion == 4,
@@ -350,7 +350,7 @@ impl<B: Backend, M> ResNetConfig<B, M> {
 
 impl<B: Backend> ResNetConfig<B, BasicBlock<B>> {
     /// Initialize a new [ResNet](ResNet) module.
-    pub fn init(self, device: &Device<B>) -> ResNet<B, BasicBlock<B>> {
+    fn init(self, device: &Device<B>) -> ResNet<B, BasicBlock<B>> {
         // Conv initializer
         let initializer = Initializer::KaimingNormal {
             gain: SQRT_2, // recommended value for ReLU
@@ -372,7 +372,7 @@ impl<B: Backend> ResNetConfig<B, BasicBlock<B>> {
     }
 
     /// Initialize a new [ResNet](ResNet) module with a [record](ResNetRecord).
-    pub fn init_with(&self, record: ResNetRecord<B, BasicBlock<B>>) -> ResNet<B, BasicBlock<B>> {
+    fn init_with(&self, record: ResNetRecord<B, BasicBlock<B>>) -> ResNet<B, BasicBlock<B>> {
         ResNet {
             conv1: self.conv1.init_with(record.conv1),
             bn1: self.bn1.init_with(record.bn1),
@@ -390,7 +390,7 @@ impl<B: Backend> ResNetConfig<B, BasicBlock<B>> {
 
 impl<B: Backend> ResNetConfig<B, Bottleneck<B>> {
     /// Initialize a new [ResNet](ResNet) module.
-    pub fn init(self, device: &Device<B>) -> ResNet<B, Bottleneck<B>> {
+    fn init(self, device: &Device<B>) -> ResNet<B, Bottleneck<B>> {
         // Conv initializer
         let initializer = Initializer::KaimingNormal {
             gain: SQRT_2, // recommended value for ReLU
@@ -412,7 +412,7 @@ impl<B: Backend> ResNetConfig<B, Bottleneck<B>> {
     }
 
     /// Initialize a new [ResNet](ResNet) module with a [record](ResNetRecord).
-    pub fn init_with(&self, record: ResNetRecord<B, Bottleneck<B>>) -> ResNet<B, Bottleneck<B>> {
+    fn init_with(&self, record: ResNetRecord<B, Bottleneck<B>>) -> ResNet<B, Bottleneck<B>> {
         ResNet {
             conv1: self.conv1.init_with(record.conv1),
             bn1: self.bn1.init_with(record.bn1),

--- a/resnet-burn/src/model/resnet.rs
+++ b/resnet-burn/src/model/resnet.rs
@@ -1,3 +1,6 @@
+use core::f64::consts::SQRT_2;
+use core::marker::PhantomData;
+
 use burn::{
     module::Module,
     nn::{
@@ -8,7 +11,21 @@ use burn::{
     tensor::{backend::Backend, Device, Tensor},
 };
 
-use super::block::{BasicBlock, Bottleneck, LayerBlock, ResidualBlock};
+use super::block::{BasicBlock, Bottleneck, LayerBlock, LayerBlockConfig, ResidualBlock};
+
+#[cfg(feature = "pretrained")]
+use {
+    super::weights::{self, WeightsMeta},
+    burn::record::{FullPrecisionSettings, Recorder, RecorderError},
+    burn_import::pytorch::{LoadArgs, PyTorchFileRecorder},
+};
+
+// ResNet residual layer block configs
+const RESNET18_BLOCKS: [usize; 4] = [2, 2, 2, 2];
+const RESNET34_BLOCKS: [usize; 4] = [3, 4, 6, 3];
+const RESNET50_BLOCKS: [usize; 4] = [3, 4, 6, 3];
+const RESNET101_BLOCKS: [usize; 4] = [3, 4, 23, 3];
+const RESNET152_BLOCKS: [usize; 4] = [3, 8, 36, 3];
 
 /// ResNet implementation.
 /// Derived from [torchivision.models.resnet.ResNet](https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py)
@@ -27,57 +44,6 @@ pub struct ResNet<B: Backend, M> {
 }
 
 impl<B: Backend, M: ResidualBlock<B>> ResNet<B, M> {
-    fn new(blocks: [usize; 4], num_classes: usize, expansion: usize, device: &Device<B>) -> Self {
-        // `new()` is private but still check just in case...
-        assert!(
-            expansion == 1 || expansion == 4,
-            "ResNet module only supports expansion values [1, 4] for residual blocks"
-        );
-
-        // 7x7 conv, 64, /2
-        let conv1 = Conv2dConfig::new([3, 64], [7, 7])
-            .with_stride([2, 2])
-            .with_padding(PaddingConfig2d::Explicit(3, 3))
-            .with_bias(false)
-            .with_initializer(Initializer::KaimingNormal {
-                gain: f64::sqrt(2.0), // recommended value for ReLU
-                fan_out_only: true,
-            })
-            .init(device);
-        let bn1 = BatchNormConfig::new(64).init(device);
-        let relu = ReLU::new();
-        // 3x3 maxpool, /2
-        let maxpool = MaxPool2dConfig::new([3, 3])
-            .with_strides([2, 2])
-            .with_padding(PaddingConfig2d::Explicit(1, 1))
-            .init();
-
-        // Residual blocks
-        let layer1 = LayerBlock::new(blocks[0], 64, 64 * expansion, 1, device);
-        let layer2 = LayerBlock::new(blocks[1], 64 * expansion, 128 * expansion, 2, device);
-        let layer3 = LayerBlock::new(blocks[2], 128 * expansion, 256 * expansion, 2, device);
-        let layer4 = LayerBlock::new(blocks[3], 256 * expansion, 512 * expansion, 2, device);
-
-        // Average pooling [B, 512 * expansion, H, W] -> [B, 512 * expansion, 1, 1]
-        let avgpool = AdaptiveAvgPool2dConfig::new([1, 1]).init();
-
-        // Output layer
-        let fc = LinearConfig::new(512 * expansion, num_classes).init(device);
-
-        Self {
-            conv1,
-            bn1,
-            relu,
-            maxpool,
-            layer1,
-            layer2,
-            layer3,
-            layer4,
-            avgpool,
-            fc,
-        }
-    }
-
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 2> {
         // First block
         let out = self.conv1.forward(input);
@@ -94,10 +60,34 @@ impl<B: Backend, M: ResidualBlock<B>> ResNet<B, M> {
         let out = self.avgpool.forward(out);
         // Reshape [B, C, 1, 1] -> [B, C]
         let out = out.flatten(1, 3);
-        // let out: Tensor<B, 3> = out.squeeze(3);
-        // let out: Tensor<B, 2> = out.squeeze(2);
 
         self.fc.forward(out)
+    }
+}
+
+#[cfg(feature = "pretrained")]
+impl<B: Backend, M: Module<B>> ResNet<B, M> {
+    /// Load specified pre-trained PyTorch weights as a record.
+    fn load_weights_record(
+        weights: &weights::Weights,
+        device: &Device<B>,
+    ) -> Result<ResNetRecord<B, M>, RecorderError> {
+        // Download torch weights
+        let torch_weights = weights.download().map_err(|err| {
+            RecorderError::Unknown(format!("Could not download weights.\nError: {err}"))
+        })?;
+
+        // Load weights from torch state_dict
+        let load_args = LoadArgs::new(torch_weights)
+            // Map *.downsample.0.* -> *.downsample.conv.*
+            .with_key_remap("(.+)\\.downsample\\.0\\.(.+)", "$1.downsample.conv.$2")
+            // Map *.downsample.1.* -> *.downsample.bn.*
+            .with_key_remap("(.+)\\.downsample\\.1\\.(.+)", "$1.downsample.bn.$2")
+            // Map layer[i].[j].* -> layer[i].blocks.[j].*
+            .with_key_remap("(layer[1-4])\\.([0-9])\\.(.+)", "$1.blocks.$2.$3");
+        let record = PyTorchFileRecorder::<FullPrecisionSettings>::new().load(load_args, device)?;
+
+        Ok(record)
     }
 }
 
@@ -113,7 +103,32 @@ impl<B: Backend> ResNet<B, BasicBlock<B>> {
     ///
     /// A ResNet-18 module.
     pub fn resnet18(num_classes: usize, device: &Device<B>) -> Self {
-        Self::new([2, 2, 2, 2], num_classes, 1, device)
+        ResNetConfig::<B, BasicBlock<B>>::new(RESNET18_BLOCKS, num_classes, 1).init(device)
+    }
+
+    /// ResNet-18 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
+    /// with pre-trained weights.
+    ///
+    /// # Arguments
+    ///
+    /// * `weights`: Pre-trained weights to load.
+    /// * `device` - Device to create the module on.
+    ///
+    /// # Returns
+    ///
+    /// A ResNet-18 module with pre-trained weights.
+    #[cfg(feature = "pretrained")]
+    pub fn resnet18_pretrained(
+        weights: weights::ResNet18,
+        device: &Device<B>,
+    ) -> Result<Self, RecorderError> {
+        let weights = weights.weights();
+        let record = Self::load_weights_record(&weights, device)?;
+
+        let model = ResNetConfig::<B, BasicBlock<B>>::new(RESNET18_BLOCKS, weights.num_classes, 1)
+            .init_with(record);
+
+        Ok(model)
     }
 
     /// ResNet-34 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385).
@@ -127,7 +142,31 @@ impl<B: Backend> ResNet<B, BasicBlock<B>> {
     ///
     /// A ResNet-34 module.
     pub fn resnet34(num_classes: usize, device: &Device<B>) -> Self {
-        Self::new([3, 4, 6, 3], num_classes, 1, device)
+        ResNetConfig::<B, BasicBlock<B>>::new(RESNET34_BLOCKS, num_classes, 1).init(device)
+    }
+
+    /// ResNet-34 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
+    /// with pre-trained weights.
+    ///
+    /// # Arguments
+    ///
+    /// * `weights`: Pre-trained weights to load.
+    /// * `device` - Device to create the module on.
+    ///
+    /// # Returns
+    ///
+    /// A ResNet-34 module with pre-trained weights.
+    #[cfg(feature = "pretrained")]
+    pub fn resnet34_pretrained(
+        weights: weights::ResNet34,
+        device: &Device<B>,
+    ) -> Result<Self, RecorderError> {
+        let weights = weights.weights();
+        let record = Self::load_weights_record(&weights, device)?;
+        let model = ResNetConfig::<B, BasicBlock<B>>::new(RESNET34_BLOCKS, weights.num_classes, 1)
+            .init_with(record);
+
+        Ok(model)
     }
 }
 
@@ -143,7 +182,31 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ///
     /// A ResNet-50 module.
     pub fn resnet50(num_classes: usize, device: &Device<B>) -> Self {
-        Self::new([3, 4, 6, 3], num_classes, 4, device)
+        ResNetConfig::<B, Bottleneck<B>>::new(RESNET50_BLOCKS, num_classes, 4).init(device)
+    }
+
+    /// ResNet-50 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
+    /// with pre-trained weights.
+    ///
+    /// # Arguments
+    ///
+    /// * `weights`: Pre-trained weights to load.
+    /// * `device` - Device to create the module on.
+    ///
+    /// # Returns
+    ///
+    /// A ResNet-50 module with pre-trained weights.
+    #[cfg(feature = "pretrained")]
+    pub fn resnet50_pretrained(
+        weights: weights::ResNet50,
+        device: &Device<B>,
+    ) -> Result<Self, RecorderError> {
+        let weights = weights.weights();
+        let record = Self::load_weights_record(&weights, device)?;
+        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET50_BLOCKS, weights.num_classes, 1)
+            .init_with(record);
+
+        Ok(model)
     }
 
     /// ResNet-101 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385).
@@ -157,7 +220,31 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ///
     /// A ResNet-101 module.
     pub fn resnet101(num_classes: usize, device: &Device<B>) -> Self {
-        Self::new([3, 4, 23, 3], num_classes, 4, device)
+        ResNetConfig::<B, Bottleneck<B>>::new(RESNET101_BLOCKS, num_classes, 4).init(device)
+    }
+
+    /// ResNet-101 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
+    /// with pre-trained weights.
+    ///
+    /// # Arguments
+    ///
+    /// * `weights`: Pre-trained weights to load.
+    /// * `device` - Device to create the module on.
+    ///
+    /// # Returns
+    ///
+    /// A ResNet-101 module with pre-trained weights.
+    #[cfg(feature = "pretrained")]
+    pub fn resnet101_pretrained(
+        weights: weights::ResNet50,
+        device: &Device<B>,
+    ) -> Result<Self, RecorderError> {
+        let weights = weights.weights();
+        let record = Self::load_weights_record(&weights, device)?;
+        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET101_BLOCKS, weights.num_classes, 1)
+            .init_with(record);
+
+        Ok(model)
     }
 
     /// ResNet-152 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385).
@@ -171,6 +258,172 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ///
     /// A ResNet-152 module.
     pub fn resnet152(num_classes: usize, device: &Device<B>) -> Self {
-        Self::new([3, 8, 36, 3], num_classes, 4, device)
+        ResNetConfig::<B, Bottleneck<B>>::new(RESNET152_BLOCKS, num_classes, 4).init(device)
+    }
+
+    /// ResNet-152 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
+    /// with pre-trained weights.
+    ///
+    /// # Arguments
+    ///
+    /// * `weights`: Pre-trained weights to load.
+    /// * `device` - Device to create the module on.
+    ///
+    /// # Returns
+    ///
+    /// A ResNet-152 module with pre-trained weights.
+    #[cfg(feature = "pretrained")]
+    pub fn resnet152_pretrained(
+        weights: weights::ResNet50,
+        device: &Device<B>,
+    ) -> Result<Self, RecorderError> {
+        let weights = weights.weights();
+        let record = Self::load_weights_record(&weights, device)?;
+        let model = ResNetConfig::<B, Bottleneck<B>>::new(RESNET152_BLOCKS, weights.num_classes, 1)
+            .init_with(record);
+
+        Ok(model)
+    }
+}
+
+/// [ResNet](ResNet) configuration.
+struct ResNetConfig<B, M> {
+    conv1: Conv2dConfig,
+    bn1: BatchNormConfig,
+    maxpool: MaxPool2dConfig,
+    layer1: LayerBlockConfig<M>,
+    layer2: LayerBlockConfig<M>,
+    layer3: LayerBlockConfig<M>,
+    layer4: LayerBlockConfig<M>,
+    avgpool: AdaptiveAvgPool2dConfig,
+    fc: LinearConfig,
+    _backend: PhantomData<B>,
+}
+
+impl<B: Backend, M> ResNetConfig<B, M> {
+    /// Create a new instance of the ResNet [config](ResNetConfig).
+    pub fn new(blocks: [usize; 4], num_classes: usize, expansion: usize) -> Self {
+        // `new()` is private but still check just in case...
+        assert!(
+            expansion == 1 || expansion == 4,
+            "ResNet module only supports expansion values [1, 4] for residual blocks"
+        );
+
+        // 7x7 conv, 64, /2
+        let conv1 = Conv2dConfig::new([3, 64], [7, 7])
+            .with_stride([2, 2])
+            .with_padding(PaddingConfig2d::Explicit(3, 3))
+            .with_bias(false);
+        let bn1 = BatchNormConfig::new(64);
+
+        // 3x3 maxpool, /2
+        let maxpool = MaxPool2dConfig::new([3, 3])
+            .with_strides([2, 2])
+            .with_padding(PaddingConfig2d::Explicit(1, 1));
+
+        // Residual blocks
+        let layer1 = LayerBlockConfig::new(blocks[0], 64, 64 * expansion, 1);
+        let layer2 = LayerBlockConfig::new(blocks[1], 64 * expansion, 128 * expansion, 2);
+        let layer3 = LayerBlockConfig::new(blocks[2], 128 * expansion, 256 * expansion, 2);
+        let layer4 = LayerBlockConfig::new(blocks[3], 256 * expansion, 512 * expansion, 2);
+
+        // Average pooling [B, 512 * expansion, H, W] -> [B, 512 * expansion, 1, 1]
+        let avgpool = AdaptiveAvgPool2dConfig::new([1, 1]);
+
+        // Output layer
+        let fc = LinearConfig::new(512 * expansion, num_classes);
+
+        Self {
+            conv1,
+            bn1,
+            maxpool,
+            layer1,
+            layer2,
+            layer3,
+            layer4,
+            avgpool,
+            fc,
+            _backend: PhantomData,
+        }
+    }
+}
+
+impl<B: Backend> ResNetConfig<B, BasicBlock<B>> {
+    /// Initialize a new [ResNet](ResNet) module.
+    pub fn init(self, device: &Device<B>) -> ResNet<B, BasicBlock<B>> {
+        // Conv initializer
+        let initializer = Initializer::KaimingNormal {
+            gain: SQRT_2, // recommended value for ReLU
+            fan_out_only: true,
+        };
+
+        ResNet {
+            conv1: self.conv1.with_initializer(initializer).init(device),
+            bn1: self.bn1.init(device),
+            relu: ReLU::new(),
+            maxpool: self.maxpool.init(),
+            layer1: self.layer1.init(device),
+            layer2: self.layer2.init(device),
+            layer3: self.layer3.init(device),
+            layer4: self.layer4.init(device),
+            avgpool: self.avgpool.init(),
+            fc: self.fc.init(device),
+        }
+    }
+
+    /// Initialize a new [ResNet](ResNet) module with a [record](ResNetRecord).
+    pub fn init_with(&self, record: ResNetRecord<B, BasicBlock<B>>) -> ResNet<B, BasicBlock<B>> {
+        ResNet {
+            conv1: self.conv1.init_with(record.conv1),
+            bn1: self.bn1.init_with(record.bn1),
+            relu: ReLU::new(),
+            maxpool: self.maxpool.init(),
+            layer1: self.layer1.init_with(record.layer1),
+            layer2: self.layer2.init_with(record.layer2),
+            layer3: self.layer3.init_with(record.layer3),
+            layer4: self.layer4.init_with(record.layer4),
+            avgpool: self.avgpool.init(),
+            fc: self.fc.init_with(record.fc),
+        }
+    }
+}
+
+impl<B: Backend> ResNetConfig<B, Bottleneck<B>> {
+    /// Initialize a new [ResNet](ResNet) module.
+    pub fn init(self, device: &Device<B>) -> ResNet<B, Bottleneck<B>> {
+        // Conv initializer
+        let initializer = Initializer::KaimingNormal {
+            gain: SQRT_2, // recommended value for ReLU
+            fan_out_only: true,
+        };
+
+        ResNet {
+            conv1: self.conv1.with_initializer(initializer).init(device),
+            bn1: self.bn1.init(device),
+            relu: ReLU::new(),
+            maxpool: self.maxpool.init(),
+            layer1: self.layer1.init(device),
+            layer2: self.layer2.init(device),
+            layer3: self.layer3.init(device),
+            layer4: self.layer4.init(device),
+            avgpool: self.avgpool.init(),
+            fc: self.fc.init(device),
+        }
+    }
+
+    /// Initialize a new [ResNet](ResNet) module with a [record](ResNetRecord).
+    pub fn init_with(&self, record: ResNetRecord<B, Bottleneck<B>>) -> ResNet<B, Bottleneck<B>> {
+        ResNet {
+            conv1: self.conv1.init_with(record.conv1),
+            bn1: self.bn1.init_with(record.bn1),
+            relu: ReLU::new(),
+            maxpool: self.maxpool.init(),
+            layer1: self.layer1.init_with(record.layer1),
+            layer2: self.layer2.init_with(record.layer2),
+            layer3: self.layer3.init_with(record.layer3),
+            layer4: self.layer4.init_with(record.layer4),
+            avgpool: self.avgpool.init(),
+            fc: self.fc.init_with(record.fc),
+        }
     }
 }

--- a/resnet-burn/src/model/weights.rs
+++ b/resnet-burn/src/model/weights.rs
@@ -1,0 +1,160 @@
+/// Pre-trained weights metadata.
+pub struct Weights {
+    pub(super) url: &'static str,
+    pub(super) num_classes: usize,
+}
+
+#[cfg(feature = "pretrained")]
+mod downloader {
+    use super::*;
+    use burn::data::network::downloader;
+    use std::fs::{create_dir_all, File};
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    impl Weights {
+        /// Download the pre-trained weights to the local cache directory.
+        pub fn download(&self) -> Result<PathBuf, std::io::Error> {
+            // Model cache directory
+            let model_dir = dirs::home_dir()
+                .expect("Should be able to get home directory")
+                .join(".cache")
+                .join("resnet-burn");
+
+            if !model_dir.exists() {
+                create_dir_all(&model_dir)?;
+            }
+
+            let file_base_name = self.url.rsplit_once('/').unwrap().1;
+            let file_name = model_dir.join(file_base_name);
+            if !file_name.exists() {
+                // Download file content
+                let bytes = downloader::download_file_as_bytes(self.url, file_base_name);
+
+                // Write content to file
+                let mut output_file = File::create(&file_name)?;
+                let bytes_written = output_file.write(&bytes)?;
+
+                if bytes_written != bytes.len() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "Failed to write the whole model weights file.",
+                    ));
+                }
+            }
+
+            Ok(file_name)
+        }
+    }
+}
+
+pub trait WeightsMeta {
+    fn weights(&self) -> Weights;
+}
+
+/// ResNet-18 pre-trained weights.
+pub enum ResNet18 {
+    /// These weights reproduce closely the results of the original paper.
+    /// Top-1 accuracy: 69.758%.
+    /// Top-5 accuracy: 89.078%.
+    ImageNet1kV1,
+}
+impl WeightsMeta for ResNet18 {
+    fn weights(&self) -> Weights {
+        Weights {
+            url: "https://download.pytorch.org/models/resnet18-f37072fd.pth",
+            num_classes: 1000,
+        }
+    }
+}
+
+/// ResNet-34 pre-trained weights.
+pub enum ResNet34 {
+    /// These weights reproduce closely the results of the original paper.
+    /// Top-1 accuracy: 73.314%.
+    /// Top-5 accuracy: 91.420%.
+    ImageNet1kV1,
+}
+impl WeightsMeta for ResNet34 {
+    fn weights(&self) -> Weights {
+        Weights {
+            url: "https://download.pytorch.org/models/resnet34-b627a593.pth",
+            num_classes: 1000,
+        }
+    }
+}
+
+/// ResNet-50 pre-trained weights.
+pub enum ResNet50 {
+    /// These weights reproduce closely the results of the original paper.
+    /// Top-1 accuracy: 76.130%.
+    /// Top-5 accuracy: 92.862%.
+    ImageNet1kV1,
+    /// These weights improve upon the results of the original paper with a new training
+    /// [recipe](https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives).
+    /// Top-1 accuracy: 80.858%.
+    /// Top-5 accuracy: 95.434%.
+    ImageNet1kV2,
+}
+impl WeightsMeta for ResNet50 {
+    fn weights(&self) -> Weights {
+        let url = match *self {
+            ResNet50::ImageNet1kV1 => "https://download.pytorch.org/models/resnet50-0676ba61.pth",
+            ResNet50::ImageNet1kV2 => "https://download.pytorch.org/models/resnet50-11ad3fa6.pth",
+        };
+        Weights {
+            url,
+            num_classes: 1000,
+        }
+    }
+}
+
+/// ResNet-101 pre-trained weights.
+pub enum ResNet101 {
+    /// These weights reproduce closely the results of the original paper.
+    /// Top-1 accuracy: 77.374%.
+    /// Top-5 accuracy: 93.546%.
+    ImageNet1kV1,
+    /// These weights improve upon the results of the original paper with a new training
+    /// [recipe](https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives).
+    /// Top-1 accuracy: 81.886%.
+    /// Top-5 accuracy: 95.780%.
+    ImageNet1kV2,
+}
+impl WeightsMeta for ResNet101 {
+    fn weights(&self) -> Weights {
+        let url = match *self {
+            ResNet101::ImageNet1kV1 => "https://download.pytorch.org/models/resnet101-63fe2227.pth",
+            ResNet101::ImageNet1kV2 => "https://download.pytorch.org/models/resnet101-cd907fc2.pth",
+        };
+        Weights {
+            url,
+            num_classes: 1000,
+        }
+    }
+}
+
+/// ResNet-152 pre-trained weights.
+pub enum ResNet152 {
+    /// These weights reproduce closely the results of the original paper.
+    /// Top-1 accuracy: 78.312%.
+    /// Top-5 accuracy: 94.046%.
+    ImageNet1kV1,
+    /// These weights improve upon the results of the original paper with a new training
+    /// [recipe](https://pytorch.org/blog/how-to-train-state-of-the-art-models-using-torchvision-latest-primitives).
+    /// Top-1 accuracy: 82.284%.
+    /// Top-5 accuracy: 96.002%.
+    ImageNet1kV2,
+}
+impl WeightsMeta for ResNet152 {
+    fn weights(&self) -> Weights {
+        let url = match *self {
+            ResNet152::ImageNet1kV1 => "https://download.pytorch.org/models/resnet152-394f9c45.pth",
+            ResNet152::ImageNet1kV2 => "https://download.pytorch.org/models/resnet152-f82ba261.pth",
+        };
+        Weights {
+            url,
+            num_classes: 1000,
+        }
+    }
+}


### PR DESCRIPTION
This PR adds new methods to directly initialize a ResNet-{18, 34, 50, 101, 152} with ImageNet pre-trained weights from `torchvision`.

The weights are automatically downloaded from the web to a default `~/.cache/resnet-burn/` folder using `download_file_as_bytes` which provides a progress bar.

Changes:
- Refactor all modules to have configs with `init` and `init_with` methods following good practice
- Add `pretrained` feature flag
  - New `weights` module
  - New `resnet*_pretrained` methods
- Refactor example accordingly

Because loading the pre-trained weights requires a fix not yet in a released version of `candle-core`, the current burn dependency is pinned to a specific revision that pins the correct dependency.

TODO:
- [ ] Change burn dependency to a specific version once the new `candle-core` version is released and included in a burn release/patch