### PR TITLE
[ResNet] Upgrade to Burn 0.13.0

### DIFF
--- a/bert-burn/README.md
+++ b/bert-burn/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bert-burn = { git = "https://github.com/burn-rs/models", package = "bert-burn", default-features = false }
+bert-burn = { git = "https://github.com/tracel-ai/models", package = "bert-burn", default-features = false }
 ```
 
 ## Example Usage

--- a/resnet-burn/Cargo.toml
+++ b/resnet-burn/Cargo.toml
@@ -12,8 +12,8 @@ pretrained = ["burn/network", "std", "dep:dirs"]
 
 [dependencies]
 # Note: default-features = false is needed to disable std
-burn = { path = "../../burn/crates/burn", default-features = false }
-burn-import = { path = "../../burn/crates/burn-import" }
+burn = { version = "0.13.0", default-features = false }
+burn-import = "0.13.0"
 dirs = { version = "5.0.1", optional = true }
 serde = { version = "1.0.192", default-features = false, features = [
     "derive",
@@ -21,7 +21,5 @@ serde = { version = "1.0.192", default-features = false, features = [
 ] } # alloc is for no_std, derive is needed
 
 [dev-dependencies]
-burn = { path = "../../burn/crates/burn", features = [
-    "ndarray",
-] }
-image = { version = "0.24.7", features = ["png", "jpeg"] }
+burn = { version = "0.13.0", features = ["ndarray"] }
+image = { version = "0.24.9", features = ["png", "jpeg"] }

--- a/resnet-burn/Cargo.toml
+++ b/resnet-burn/Cargo.toml
@@ -12,8 +12,8 @@ pretrained = ["burn/network", "std", "dep:dirs"]
 
 [dependencies]
 # Note: default-features = false is needed to disable std
-burn = { git = "https://github.com/tracel-ai/burn.git", rev = "9a2cbadd41161c8aac142bbcb9c2ceaf5ffd6edd", default-features = false }
-burn-import = { git = "https://github.com/tracel-ai/burn.git", rev = "9a2cbadd41161c8aac142bbcb9c2ceaf5ffd6edd" }
+burn = { path = "../../burn/crates/burn", default-features = false }
+burn-import = { path = "../../burn/crates/burn-import" }
 dirs = { version = "5.0.1", optional = true }
 serde = { version = "1.0.192", default-features = false, features = [
     "derive",
@@ -21,7 +21,7 @@ serde = { version = "1.0.192", default-features = false, features = [
 ] } # alloc is for no_std, derive is needed
 
 [dev-dependencies]
-burn = { git = "https://github.com/tracel-ai/burn.git", rev = "9a2cbadd41161c8aac142bbcb9c2ceaf5ffd6edd", features = [
+burn = { path = "../../burn/crates/burn", features = [
     "ndarray",
 ] }
 image = { version = "0.24.7", features = ["png", "jpeg"] }

--- a/resnet-burn/README.md
+++ b/resnet-burn/README.md
@@ -14,14 +14,14 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-resnet-burn = { git = "https://github.com/burn-rs/models", package = "resnet-burn", default-features = false }
+resnet-burn = { git = "https://github.com/tracel-ai/models", package = "resnet-burn", default-features = false }
 ```
 
 If you want to get the pre-trained ImageNet weights, enable the `pretrained` feature flag.
 
 ```toml
 [dependencies]
-resnet-burn = { git = "https://github.com/burn-rs/models", package = "resnet-burn", features = ["pretrained"] }
+resnet-burn = { git = "https://github.com/tracel-ai/models", package = "resnet-burn", features = ["pretrained"] }
 ```
 
 **Important:** this feature requires `std`.

--- a/resnet-burn/examples/inference.rs
+++ b/resnet-burn/examples/inference.rs
@@ -29,7 +29,7 @@ pub fn main() {
 
     // Create ResNet-18
     let device = Default::default();
-    let model: ResNet<NdArray, _> =
+    let model: ResNet<NdArray> =
         ResNet::resnet18_pretrained(weights::ResNet18::ImageNet1kV1, &device)
             .map_err(|err| format!("Failed to load pre-trained weights.\nError: {err}"))
             .unwrap();

--- a/resnet-burn/src/model/resnet.rs
+++ b/resnet-burn/src/model/resnet.rs
@@ -1,5 +1,4 @@
 use core::f64::consts::SQRT_2;
-use core::marker::PhantomData;
 
 use burn::{
     module::Module,
@@ -11,7 +10,6 @@ use burn::{
     tensor::{backend::Backend, Device, Tensor},
 };
 
-pub use super::block::{BasicBlock, Bottleneck, ResidualBlock};
 use super::block::{LayerBlock, LayerBlockConfig};
 
 #[cfg(feature = "pretrained")]
@@ -31,20 +29,20 @@ const RESNET152_BLOCKS: [usize; 4] = [3, 8, 36, 3];
 /// ResNet implementation.
 /// Derived from [torchivision.models.resnet.ResNet](https://github.com/pytorch/vision/blob/main/torchvision/models/resnet.py)
 #[derive(Module, Debug)]
-pub struct ResNet<B: Backend, M: Module<B>> {
+pub struct ResNet<B: Backend> {
     conv1: Conv2d<B>,
     bn1: BatchNorm<B, 2>,
     relu: Relu,
     maxpool: MaxPool2d,
-    layer1: LayerBlock<B, M>,
-    layer2: LayerBlock<B, M>,
-    layer3: LayerBlock<B, M>,
-    layer4: LayerBlock<B, M>,
+    layer1: LayerBlock<B>,
+    layer2: LayerBlock<B>,
+    layer3: LayerBlock<B>,
+    layer4: LayerBlock<B>,
     avgpool: AdaptiveAvgPool2d,
     fc: Linear<B>,
 }
 
-impl<B: Backend, M: ResidualBlock<B> + Module<B>> ResNet<B, M> {
+impl<B: Backend> ResNet<B> {
     pub fn forward(&self, input: Tensor<B, 4>) -> Tensor<B, 2> {
         // First block
         let out = self.conv1.forward(input);
@@ -64,35 +62,7 @@ impl<B: Backend, M: ResidualBlock<B> + Module<B>> ResNet<B, M> {
 
         self.fc.forward(out)
     }
-}
 
-#[cfg(feature = "pretrained")]
-impl<B: Backend, M: Module<B>> ResNet<B, M> {
-    /// Load specified pre-trained PyTorch weights as a record.
-    fn load_weights_record(
-        weights: &weights::Weights,
-        device: &Device<B>,
-    ) -> Result<ResNetRecord<B, M>, RecorderError> {
-        // Download torch weights
-        let torch_weights = weights.download().map_err(|err| {
-            RecorderError::Unknown(format!("Could not download weights.\nError: {err}"))
-        })?;
-
-        // Load weights from torch state_dict
-        let load_args = LoadArgs::new(torch_weights)
-            // Map *.downsample.0.* -> *.downsample.conv.*
-            .with_key_remap("(.+)\\.downsample\\.0\\.(.+)", "$1.downsample.conv.$2")
-            // Map *.downsample.1.* -> *.downsample.bn.*
-            .with_key_remap("(.+)\\.downsample\\.1\\.(.+)", "$1.downsample.bn.$2")
-            // Map layer[i].[j].* -> layer[i].blocks.[j].*
-            .with_key_remap("(layer[1-4])\\.([0-9]+)\\.(.+)", "$1.blocks.$2.$3");
-        let record = PyTorchFileRecorder::<FullPrecisionSettings>::new().load(load_args, device)?;
-
-        Ok(record)
-    }
-}
-
-impl<B: Backend> ResNet<B, BasicBlock<B>> {
     /// ResNet-18 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385).
     ///
     /// # Arguments
@@ -104,7 +74,7 @@ impl<B: Backend> ResNet<B, BasicBlock<B>> {
     ///
     /// A ResNet-18 module.
     pub fn resnet18(num_classes: usize, device: &Device<B>) -> Self {
-        ResNetConfig::<B, BasicBlock<B>>::new(RESNET18_BLOCKS, num_classes, 1).init(device)
+        ResNetConfig::new(RESNET18_BLOCKS, num_classes, 1).init(device)
     }
 
     /// ResNet-18 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
@@ -125,8 +95,7 @@ impl<B: Backend> ResNet<B, BasicBlock<B>> {
     ) -> Result<Self, RecorderError> {
         let weights = weights.weights();
         let record = Self::load_weights_record(&weights, device)?;
-        let model =
-            ResNet::<B, BasicBlock<B>>::resnet18(weights.num_classes, &device).load_record(record);
+        let model = ResNet::<B>::resnet18(weights.num_classes, &device).load_record(record);
 
         Ok(model)
     }
@@ -142,7 +111,7 @@ impl<B: Backend> ResNet<B, BasicBlock<B>> {
     ///
     /// A ResNet-34 module.
     pub fn resnet34(num_classes: usize, device: &Device<B>) -> Self {
-        ResNetConfig::<B, BasicBlock<B>>::new(RESNET34_BLOCKS, num_classes, 1).init(device)
+        ResNetConfig::new(RESNET34_BLOCKS, num_classes, 1).init(device)
     }
 
     /// ResNet-34 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
@@ -163,14 +132,11 @@ impl<B: Backend> ResNet<B, BasicBlock<B>> {
     ) -> Result<Self, RecorderError> {
         let weights = weights.weights();
         let record = Self::load_weights_record(&weights, device)?;
-        let model =
-            ResNet::<B, BasicBlock<B>>::resnet34(weights.num_classes, &device).load_record(record);
+        let model = ResNet::<B>::resnet34(weights.num_classes, &device).load_record(record);
 
         Ok(model)
     }
-}
 
-impl<B: Backend> ResNet<B, Bottleneck<B>> {
     /// ResNet-50 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385).
     ///
     /// # Arguments
@@ -182,7 +148,7 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ///
     /// A ResNet-50 module.
     pub fn resnet50(num_classes: usize, device: &Device<B>) -> Self {
-        ResNetConfig::<B, Bottleneck<B>>::new(RESNET50_BLOCKS, num_classes, 4).init(device)
+        ResNetConfig::new(RESNET50_BLOCKS, num_classes, 4).init(device)
     }
 
     /// ResNet-50 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
@@ -203,8 +169,7 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ) -> Result<Self, RecorderError> {
         let weights = weights.weights();
         let record = Self::load_weights_record(&weights, device)?;
-        let model =
-            ResNet::<B, Bottleneck<B>>::resnet50(weights.num_classes, &device).load_record(record);
+        let model = ResNet::<B>::resnet50(weights.num_classes, &device).load_record(record);
 
         Ok(model)
     }
@@ -220,7 +185,7 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ///
     /// A ResNet-101 module.
     pub fn resnet101(num_classes: usize, device: &Device<B>) -> Self {
-        ResNetConfig::<B, Bottleneck<B>>::new(RESNET101_BLOCKS, num_classes, 4).init(device)
+        ResNetConfig::new(RESNET101_BLOCKS, num_classes, 4).init(device)
     }
 
     /// ResNet-101 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
@@ -241,8 +206,7 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ) -> Result<Self, RecorderError> {
         let weights = weights.weights();
         let record = Self::load_weights_record(&weights, device)?;
-        let model =
-            ResNet::<B, Bottleneck<B>>::resnet101(weights.num_classes, &device).load_record(record);
+        let model = ResNet::<B>::resnet101(weights.num_classes, &device).load_record(record);
 
         Ok(model)
     }
@@ -258,7 +222,7 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ///
     /// A ResNet-152 module.
     pub fn resnet152(num_classes: usize, device: &Device<B>) -> Self {
-        ResNetConfig::<B, Bottleneck<B>>::new(RESNET152_BLOCKS, num_classes, 4).init(device)
+        ResNetConfig::new(RESNET152_BLOCKS, num_classes, 4).init(device)
     }
 
     /// ResNet-152 from [`Deep Residual Learning for Image Recognition`](https://arxiv.org/abs/1512.03385)
@@ -279,28 +243,52 @@ impl<B: Backend> ResNet<B, Bottleneck<B>> {
     ) -> Result<Self, RecorderError> {
         let weights = weights.weights();
         let record = Self::load_weights_record(&weights, device)?;
-        let model =
-            ResNet::<B, Bottleneck<B>>::resnet152(weights.num_classes, &device).load_record(record);
+        let model = ResNet::<B>::resnet152(weights.num_classes, &device).load_record(record);
 
         Ok(model)
     }
 }
 
+#[cfg(feature = "pretrained")]
+impl<B: Backend> ResNet<B> {
+    /// Load specified pre-trained PyTorch weights as a record.
+    fn load_weights_record(
+        weights: &weights::Weights,
+        device: &Device<B>,
+    ) -> Result<ResNetRecord<B>, RecorderError> {
+        // Download torch weights
+        let torch_weights = weights.download().map_err(|err| {
+            RecorderError::Unknown(format!("Could not download weights.\nError: {err}"))
+        })?;
+
+        // Load weights from torch state_dict
+        let load_args = LoadArgs::new(torch_weights)
+            // Map *.downsample.0.* -> *.downsample.conv.*
+            .with_key_remap("(.+)\\.downsample\\.0\\.(.+)", "$1.downsample.conv.$2")
+            // Map *.downsample.1.* -> *.downsample.bn.*
+            .with_key_remap("(.+)\\.downsample\\.1\\.(.+)", "$1.downsample.bn.$2")
+            // Map layer[i].[j].* -> layer[i].blocks.[j].*
+            .with_key_remap("(layer[1-4])\\.([0-9]+)\\.(.+)", "$1.blocks.$2.$3");
+        let record = PyTorchFileRecorder::<FullPrecisionSettings>::new().load(load_args, device)?;
+
+        Ok(record)
+    }
+}
+
 /// [ResNet](ResNet) configuration.
-struct ResNetConfig<B, M> {
+struct ResNetConfig {
     conv1: Conv2dConfig,
     bn1: BatchNormConfig,
     maxpool: MaxPool2dConfig,
-    layer1: LayerBlockConfig<M>,
-    layer2: LayerBlockConfig<M>,
-    layer3: LayerBlockConfig<M>,
-    layer4: LayerBlockConfig<M>,
+    layer1: LayerBlockConfig,
+    layer2: LayerBlockConfig,
+    layer3: LayerBlockConfig,
+    layer4: LayerBlockConfig,
     avgpool: AdaptiveAvgPool2dConfig,
     fc: LinearConfig,
-    _backend: PhantomData<B>,
 }
 
-impl<B: Backend, M> ResNetConfig<B, M> {
+impl ResNetConfig {
     /// Create a new instance of the ResNet [config](ResNetConfig).
     fn new(blocks: [usize; 4], num_classes: usize, expansion: usize) -> Self {
         // `new()` is private but still check just in case...
@@ -322,10 +310,14 @@ impl<B: Backend, M> ResNetConfig<B, M> {
             .with_padding(PaddingConfig2d::Explicit(1, 1));
 
         // Residual blocks
-        let layer1 = LayerBlockConfig::new(blocks[0], 64, 64 * expansion, 1);
-        let layer2 = LayerBlockConfig::new(blocks[1], 64 * expansion, 128 * expansion, 2);
-        let layer3 = LayerBlockConfig::new(blocks[2], 128 * expansion, 256 * expansion, 2);
-        let layer4 = LayerBlockConfig::new(blocks[3], 256 * expansion, 512 * expansion, 2);
+        let bottleneck = expansion > 1;
+        let layer1 = LayerBlockConfig::new(blocks[0], 64, 64 * expansion, 1, bottleneck);
+        let layer2 =
+            LayerBlockConfig::new(blocks[1], 64 * expansion, 128 * expansion, 2, bottleneck);
+        let layer3 =
+            LayerBlockConfig::new(blocks[2], 128 * expansion, 256 * expansion, 2, bottleneck);
+        let layer4 =
+            LayerBlockConfig::new(blocks[3], 256 * expansion, 512 * expansion, 2, bottleneck);
 
         // Average pooling [B, 512 * expansion, H, W] -> [B, 512 * expansion, 1, 1]
         let avgpool = AdaptiveAvgPool2dConfig::new([1, 1]);
@@ -343,38 +335,13 @@ impl<B: Backend, M> ResNetConfig<B, M> {
             layer4,
             avgpool,
             fc,
-            _backend: PhantomData,
         }
     }
 }
 
-impl<B: Backend> ResNetConfig<B, BasicBlock<B>> {
+impl ResNetConfig {
     /// Initialize a new [ResNet](ResNet) module.
-    fn init(self, device: &Device<B>) -> ResNet<B, BasicBlock<B>> {
-        // Conv initializer
-        let initializer = Initializer::KaimingNormal {
-            gain: SQRT_2, // recommended value for ReLU
-            fan_out_only: true,
-        };
-
-        ResNet {
-            conv1: self.conv1.with_initializer(initializer).init(device),
-            bn1: self.bn1.init(device),
-            relu: Relu::new(),
-            maxpool: self.maxpool.init(),
-            layer1: self.layer1.init(device),
-            layer2: self.layer2.init(device),
-            layer3: self.layer3.init(device),
-            layer4: self.layer4.init(device),
-            avgpool: self.avgpool.init(),
-            fc: self.fc.init(device),
-        }
-    }
-}
-
-impl<B: Backend> ResNetConfig<B, Bottleneck<B>> {
-    /// Initialize a new [ResNet](ResNet) module.
-    fn init(self, device: &Device<B>) -> ResNet<B, Bottleneck<B>> {
+    fn init<B: Backend>(self, device: &Device<B>) -> ResNet<B> {
         // Conv initializer
         let initializer = Initializer::KaimingNormal {
             gain: SQRT_2, // recommended value for ReLU

--- a/resnet-burn/src/model/resnet.rs
+++ b/resnet-burn/src/model/resnet.rs
@@ -247,6 +247,13 @@ impl<B: Backend> ResNet<B> {
 
         Ok(model)
     }
+
+    /// Re-initialize the last layer with the specified number of output classes.
+    pub fn with_classes(mut self, num_classes: usize) -> Self {
+        let [d_input, _d_output] = self.fc.weight.dims();
+        self.fc = LinearConfig::new(d_input, num_classes).init(&self.fc.weight.device());
+        self
+    }
 }
 
 #[cfg(feature = "pretrained")]

--- a/squeezenet-burn/README.md
+++ b/squeezenet-burn/README.md
@@ -33,7 +33,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-squeezenet-burn = { git = "https://github.com/burn-rs/models", package = "squeezenet-burn", features = ["weights_embedded"], default-features = false }
+squeezenet-burn = { git = "https://github.com/tracel-ai/models", package = "squeezenet-burn", features = ["weights_embedded"], default-features = false }
 ```
 
 ### To run the example


### PR DESCRIPTION
Closes #19 

- Updated `burn` and `image` versions
- Changed `ReLU` -> `Relu`
- Removed `init_with` methods (yay lazy init)
- Refactored residual blocks to use newly supported enum modules
- Changes `burn-rs` -> `tracel-ai` github links
- Added `with_classes` method to support output layer initialization for fine-tuning