### PR TITLE
Remove explicit fusion backend in Bert example

### DIFF
--- a/bert-burn/Cargo.toml
+++ b/bert-burn/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Aasheesh Singh aasheeshdtu@gmail.com"]
 license = "MIT OR Apache-2.0"
 name = "bert-burn"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [features]

--- a/bert-burn/examples/infer-embedding.rs
+++ b/bert-burn/examples/infer-embedding.rs
@@ -133,10 +133,9 @@ mod tch_cpu {
 mod wgpu {
     use crate::{launch, ElemType};
     use burn::backend::wgpu::{AutoGraphicsApi, Wgpu, WgpuDevice};
-    use burn::backend::Fusion;
 
     pub fn run() {
-        launch::<Fusion<Wgpu<AutoGraphicsApi, ElemType, i32>>>(WgpuDevice::default());
+        launch::<Wgpu<AutoGraphicsApi, ElemType, i32>>(WgpuDevice::default());
     }
 }
 


### PR DESCRIPTION
Small issue we missed in #27

`Fusion` doesn't exist anymore with 0.13.0