### PR TITLE
Llama 3.1

### DIFF
--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -18,12 +18,12 @@ tch-cpu = ["burn/tch"]
 tch-gpu = ["burn/tch"]
 wgpu = ["burn/wgpu"]
 
+# To import pytorch weights
+import = ["burn-import"]
+
 [dependencies]
-# Note: default-features = false is needed to disable std
-burn = { path = "../../burn/crates/burn", default-features = false }
-burn-import = { path = "../../burn/crates/burn-import" }
-# burn = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c", default-features = false }
-# burn-import = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c" }
+burn = { version = "0.14.0", default-features = false, features = ["std"] }
+burn-import = { version = "0.14.0", optional = true }
 itertools = { version = "0.12.1", default-features = false, features = [
     "use_alloc",
 ] }
@@ -48,6 +48,5 @@ rand = { version = "0.8.5", default-features = false, features = [
 ] } # std_rng is for no_std
 
 [dev-dependencies]
-burn = { path = "../../burn/crates/burn", default-features = false }
-# burn = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c" }
+burn = { version = "0.14.0", default-features = false }
 clap = { version = "4.5.4", features = ["derive"] }

--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -11,6 +11,7 @@ default = ["pretrained"]
 pretrained = ["burn/network", "dep:dirs"]
 
 llama3 = ["dep:tiktoken-rs", "dep:rustc-hash", "dep:base64"]
+llama3_1 = ["llama3"]
 tiny = ["dep:tokenizers"]
 
 # Example feature flags (backend selection)
@@ -20,8 +21,10 @@ wgpu = ["burn/wgpu"]
 
 [dependencies]
 # Note: default-features = false is needed to disable std
-burn = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c", default-features = false }
-burn-import = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c" }
+burn = { path = "../../burn/crates/burn", default-features = false }
+burn-import = { path = "../../burn/crates/burn-import" }
+# burn = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c", default-features = false }
+# burn-import = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c" }
 itertools = { version = "0.12.1", default-features = false, features = [
     "use_alloc",
 ] }
@@ -46,5 +49,6 @@ rand = { version = "0.8.5", default-features = false, features = [
 ] } # std_rng is for no_std
 
 [dev-dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c" }
+burn = { path = "../../burn/crates/burn", default-features = false }
+# burn = { git = "https://github.com/tracel-ai/burn", rev = "a53f459f205889a22ecea3713bbae12d3de7eb0c" }
 clap = { version = "4.5.4", features = ["derive"] }

--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -11,7 +11,6 @@ default = ["pretrained"]
 pretrained = ["burn/network", "dep:dirs"]
 
 llama3 = ["dep:tiktoken-rs", "dep:rustc-hash", "dep:base64"]
-llama3_1 = ["llama3"]
 tiny = ["dep:tokenizers"]
 
 # Example feature flags (backend selection)

--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -16,6 +16,7 @@ tiny = ["dep:tokenizers"]
 # Example feature flags (backend selection)
 tch-cpu = ["burn/tch"]
 tch-gpu = ["burn/tch"]
+cuda = ["burn/cuda-jit"]
 wgpu = ["burn/wgpu"]
 
 # To import pytorch weights

--- a/llama-burn/NOTICES.md
+++ b/llama-burn/NOTICES.md
@@ -9,7 +9,7 @@ The model implementation was adapted from the original
 [Llama 3 implementation](https://github.com/meta-llama/llama3), which is distributed under the
 [Meta Llama 3 Community License Agreement](https://github.com/meta-llama/llama3/blob/main/LICENSE).
 The Llama 3.1 model is distributed under the
-[ Llama 3.1 Community License Agreement](https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE).
+[Llama 3.1 Community License Agreement](https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE).
 
 The TinyLlama implementation is derived from the same code, but its weights and tokenizers were
 adapted from the [original implementation](https://github.com/jzhang38/TinyLlama) distributed under

--- a/llama-burn/NOTICES.md
+++ b/llama-burn/NOTICES.md
@@ -8,6 +8,8 @@ derived from. The use of the following resources complies with the licenses prov
 The model implementation was adapted from the original
 [Llama 3 implementation](https://github.com/meta-llama/llama3), which is distributed under the
 [Meta Llama 3 Community License Agreement](https://github.com/meta-llama/llama3/blob/main/LICENSE).
+The Llama 3.1 model is distributed under the
+[ Llama 3.1 Community License Agreement](https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE).
 
 The TinyLlama implementation is derived from the same code, but its weights and tokenizers were
 adapted from the [original implementation](https://github.com/jzhang38/TinyLlama) distributed under

--- a/llama-burn/README.md
+++ b/llama-burn/README.md
@@ -24,9 +24,7 @@ llama-burn = { git = "https://github.com/tracel-ai/models", package = "llama-bur
 If you want to use Llama 3 or TinyLlama (including pre-trained weights if default features are
 active), enable the corresponding feature flag.
 
-> **Important:** these features require `std`. Note that the weights have been saved in the binary
-> format, which is more compact and faster to save & load, but might not be compatible in future
-> versions if the Burn data schema were to evolve.
+> **Important:** these features require `std`.
 
 #### Llama 3
 

--- a/llama-burn/README.md
+++ b/llama-burn/README.md
@@ -116,6 +116,18 @@ Using the `wgpu` backend:
 cargo run --release --features tiny,wgpu --example chat
 ```
 
+Using the `cuda` backend:
+
+```sh
+cargo run --release --features tiny,cuda --example chat
+```
+
 This example uses the
 [TinyLlama-1.1B-Chat-v1.0](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0)
 instruction-tuned model based on the Llama2 architecture and tokenizer.
+
+## Known Issues
+
+Based on your hardware and the model selected, the `wgpu` backend might not be able to successfully
+run the model due to the current memory management strategy. With `cuda` selected, the precision is
+set to `f32` due to compilation errors with `f16`.

--- a/llama-burn/README.md
+++ b/llama-burn/README.md
@@ -46,7 +46,7 @@ The [chat completion example](examples/chat.rs) initializes a Llama model from t
 file and generates a sequence of text based on the input prompt. The instruction-tuned model is
 loaded for dialogue applications, so the prompt is automatically formatted for chat completion.
 
-The example can be executed on the `tch` backend (CUDA or CPU) or `wgpu`.
+The example can be executed on the `tch` backend (CUDA or CPU), `cuda` or `wgpu`.
 
 | Argument        | Description                                                                                                    |
 | :-------------- | :------------------------------------------------------------------------------------------------------------- |

--- a/llama-burn/README.md
+++ b/llama-burn/README.md
@@ -83,6 +83,12 @@ Using the `wgpu` backend:
 cargo run --release --features llama3,wgpu --example chat
 ```
 
+Using the `cuda` backend:
+
+```sh
+cargo run --release --features llama3,cuda --example chat
+```
+
 **Built with Meta Llama 3.** This example uses the
 [Meta-Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct) (default)
 and [Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)

--- a/llama-burn/README.md
+++ b/llama-burn/README.md
@@ -84,8 +84,9 @@ cargo run --release --features llama3,wgpu --example chat
 ```
 
 **Built with Meta Llama 3.** This example uses the
-[Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)
-instruction-tuned model. Note that the [base pre-trained Llama-3 model](./src/pretrained.rs#L77) is
+[Meta-Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct) (default)
+and [Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)
+instruction-tuned models. Note that the [base pre-trained Llama-3 model](./src/pretrained.rs#L77) is
 also available if you wish to use it in your application.
 
 #### TinyLlama

--- a/llama-burn/README.md
+++ b/llama-burn/README.md
@@ -4,7 +4,8 @@
 
 The popular Llama LLM is here!
 
-This repository contains the [Llama 3](https://github.com/meta-llama/llama3) and
+This repository contains the [Llama 3.1](https://github.com/meta-llama/llama-models/),
+[Llama 3](https://github.com/meta-llama/llama3) and
 [TinyLlama](https://github.com/jzhang38/TinyLlama) implementations with their corresponding
 tokenizers. You can find the [Burn](https://github.com/tracel-ai/burn) implementation for the Llama
 variants in [src/llama.rs](src/llama.rs).

--- a/llama-burn/examples/chat.rs
+++ b/llama-burn/examples/chat.rs
@@ -183,6 +183,19 @@ mod wgpu {
     }
 }
 
+#[cfg(feature = "cuda")]
+mod cuda {
+    use super::*;
+    use burn::backend::{cuda_jit::CudaDevice, CudaJit};
+
+    pub fn run(args: Config) {
+        let device = CudaDevice::default();
+
+        // NOTE: compilation errors in f16
+        chat::<CudaJit<f32, i32>>(args, device);
+    }
+}
+
 pub fn main() {
     // Parse arguments
     let args = Config::parse();
@@ -193,4 +206,6 @@ pub fn main() {
     tch_cpu::run(args);
     #[cfg(feature = "wgpu")]
     wgpu::run(args);
+    #[cfg(feature = "cuda")]
+    cuda::run(args);
 }

--- a/llama-burn/examples/chat.rs
+++ b/llama-burn/examples/chat.rs
@@ -76,7 +76,7 @@ pub fn chat<B: Backend>(args: Config, device: Device<B>) {
     #[cfg(feature = "tiny")]
     {
         // TinyLlama-1.1B Chat v1.0
-        let mut llama = LlamaConfig::tiny_llama_pretrained::<B>(&device).unwrap();
+        let mut llama = LlamaConfig::tiny_llama_pretrained::<B>(args.max_seq_len, &device).unwrap();
         println!("Processing prompt: {}", prompt);
 
         // Prompt formatting for chat model
@@ -96,7 +96,7 @@ pub fn chat<B: Backend>(args: Config, device: Device<B>) {
     #[cfg(feature = "llama3")]
     {
         // Llama-3-8B-Instruct
-        let mut llama = LlamaConfig::llama3_8b_pretrained::<B>(true, &device).unwrap();
+        let mut llama = LlamaConfig::llama3_8b_pretrained::<B>(args.max_seq_len, &device).unwrap();
         println!("Processing prompt: {}", prompt);
 
         // Prompt formatting for chat model

--- a/llama-burn/examples/chat.rs
+++ b/llama-burn/examples/chat.rs
@@ -8,6 +8,9 @@ use llama_burn::{
     tokenizer::Tokenizer,
 };
 
+#[cfg(feature = "llama3")]
+use clap::ValueEnum;
+
 const DEFAULT_PROMPT: &str = "How many helicopters can a human eat in one sitting?";
 
 #[derive(Parser, Debug)]
@@ -26,7 +29,7 @@ pub struct Config {
     max_seq_len: usize,
 
     /// The number of new tokens to generate (i.e., the number of generation steps to take).
-    #[arg(long, short = 'n', default_value_t = 50)]
+    #[arg(long, short = 'n', default_value_t = 65)]
     sample_len: usize,
 
     /// The seed to use when generating random samples.
@@ -36,6 +39,23 @@ pub struct Config {
     /// The input prompt.
     #[arg(short, long, default_value_t = String::from(DEFAULT_PROMPT))]
     prompt: String,
+
+    /// The Llama 3 model version.
+    #[cfg(feature = "llama3")]
+    #[arg(long, default_value = "llama-3.1-8b-instruct")]
+    version: Llama3,
+}
+
+#[cfg(feature = "llama3")]
+#[derive(Clone, Debug, ValueEnum)]
+/// Llama-3 model variants to load.
+enum Llama3 {
+    /// Llama-3-8B-Instruct.
+    #[value(name = "llama-3-8b-instruct")]
+    V3Instruct,
+    /// Llama-3.1-8B-Instruct.
+    #[value(name = "llama-3.1-8b-instruct")]
+    V31Instruct,
 }
 
 pub fn generate<B: Backend, T: Tokenizer>(
@@ -95,8 +115,15 @@ pub fn chat<B: Backend>(args: Config, device: Device<B>) {
 
     #[cfg(feature = "llama3")]
     {
-        // Llama-3-8B-Instruct
-        let mut llama = LlamaConfig::llama3_8b_pretrained::<B>(args.max_seq_len, &device).unwrap();
+        // Llama-3-8B-Instruct or Llama-3.1-8B-Instruct
+        let mut llama = match args.version {
+            Llama3::V3Instruct => {
+                LlamaConfig::llama3_8b_pretrained::<B>(args.max_seq_len, &device).unwrap()
+            }
+            Llama3::V31Instruct => {
+                LlamaConfig::llama3_1_8b_pretrained::<B>(args.max_seq_len, &device).unwrap()
+            }
+        };
         println!("Processing prompt: {}", prompt);
 
         // Prompt formatting for chat model

--- a/llama-burn/src/cache.rs
+++ b/llama-burn/src/cache.rs
@@ -1,10 +1,11 @@
 use burn::tensor::{backend::Backend, Tensor};
 
-/// All Llama-3 models support sequence length up to 8192 tokens.
+/// All Llama-3 models support sequence length up to 8K tokens.
+#[cfg(not(feature = "llama3_1"))]
 pub(crate) const MAX_SEQ_LEN: usize = 8192;
-
-// /// All Llama-2 models support sequence length up to 4096 tokens.
-// pub(crate) const MAX_SEQ_LEN_V2: usize = 4096;
+/// All Llama-3.1 models support sequence length up to 128K tokens.
+#[cfg(feature = "llama3_1")]
+pub(crate) const MAX_SEQ_LEN: usize = 131072;
 
 // Adapted from `burn::nn::cache`
 enum CacheState<T> {

--- a/llama-burn/src/cache.rs
+++ b/llama-burn/src/cache.rs
@@ -1,12 +1,5 @@
 use burn::tensor::{backend::Backend, Tensor};
 
-/// All Llama-3 models support sequence length up to 8K tokens.
-#[cfg(not(feature = "llama3_1"))]
-pub(crate) const MAX_SEQ_LEN: usize = 8192;
-/// All Llama-3.1 models support sequence length up to 128K tokens.
-#[cfg(feature = "llama3_1")]
-pub(crate) const MAX_SEQ_LEN: usize = 131072;
-
 // Adapted from `burn::nn::cache`
 enum CacheState<T> {
     Value(T),
@@ -40,11 +33,6 @@ pub(crate) struct AutoregressiveCache<B: Backend> {
 impl<B: Backend> AutoregressiveCache<B> {
     /// Creates a new empty cache.
     pub fn new(max_seq_len: usize) -> Self {
-        assert!(
-            max_seq_len <= MAX_SEQ_LEN,
-            "Maximum sequence length must not exceed {MAX_SEQ_LEN}"
-        );
-
         Self {
             cache: TensorCache::empty(),
             max_seq_len,

--- a/llama-burn/src/llama.rs
+++ b/llama-burn/src/llama.rs
@@ -4,18 +4,24 @@ use burn::{
     config::Config,
     module::Module,
     nn::{RotaryEncoding, RotaryEncodingConfig},
-    record::{FileRecorder, HalfPrecisionSettings, Recorder, RecorderError},
+    record::{FileRecorder, HalfPrecisionSettings, RecorderError},
     tensor::{
         activation::softmax, backend::Backend, Device, ElementConversion, Int, Shape, Tensor,
         TensorData,
     },
 };
-use burn_import::pytorch::{LoadArgs, PyTorchFileRecorder};
+
+#[cfg(feature = "import")]
+use {
+    crate::transformer::TransformerRecord,
+    burn::record::Recorder,
+    burn_import::pytorch::{LoadArgs, PyTorchFileRecorder},
+};
 
 use crate::{
     sampling::Sampler,
     tokenizer::Tokenizer,
-    transformer::{KeyValueCache, Transformer, TransformerConfig, TransformerRecord},
+    transformer::{KeyValueCache, Transformer, TransformerConfig},
 };
 
 #[cfg(feature = "pretrained")]
@@ -133,6 +139,8 @@ impl LlamaConfig {
         Self::load_llama3_1_8b(
             checkpoint.to_str().unwrap(),
             tokenizer.to_str().unwrap(),
+            // "/home/laggui/workspace/llama-models/models/llama3_1/Meta-Llama-3.1-8B-Instruct/model",
+            // "/home/laggui/workspace/llama-models/models/llama3_1/Meta-Llama-3.1-8B-Instruct/tokenizer.model",
             max_seq_len,
             device,
         )
@@ -283,6 +291,7 @@ impl LlamaConfig {
     }
 
     /// Load pre-trained Llama checkpoint.
+    #[cfg(feature = "import")]
     pub fn load_pretrained<B: Backend, T: Tokenizer>(
         &self,
         checkpoint: &str,

--- a/llama-burn/src/pretrained.rs
+++ b/llama-burn/src/pretrained.rs
@@ -67,6 +67,8 @@ pub enum Llama {
     Llama3,
     /// Llama-3-8B-Instruct.
     Llama3Instruct,
+    /// Llama-3.1-8B-Instruct.
+    Llama31Instruct,
     /// TinyLlama-1.1B Chat v1.0.
     TinyLlama,
 }
@@ -83,6 +85,11 @@ impl ModelMeta for Llama {
                 name: "Llama-3-8B-Instruct",
                 model: "https://huggingface.co/tracel-ai/llama-3-8b-instruct-burn/resolve/main/model.mpk?download=true",
                 tokenizer: "https://huggingface.co/tracel-ai/llama-3-8b-instruct-burn/resolve/main/tokenizer.model?download=true",
+            },
+            Self::Llama31Instruct => Pretrained {
+                name: "Llama-3.1-8B-Instruct",
+                model: "https://huggingface.co/tracel-ai/llama-3.1-8b-instruct-burn/resolve/main/model.mpk?download=true",
+                tokenizer: "https://huggingface.co/tracel-ai/llama-3.1-8b-instruct-burn/resolve/main/tokenizer.model?download=true",
             },
             Self::TinyLlama => Pretrained {
                 name: "TinyLlama-1.1B",

--- a/llama-burn/src/tokenizer/base.rs
+++ b/llama-burn/src/tokenizer/base.rs
@@ -25,4 +25,7 @@ pub trait Tokenizer {
 
     /// End of sentence token identifier.
     fn eos_id(&self) -> u32;
+
+    /// Stop token identifiers.
+    fn stop_ids(&self) -> Vec<u32>;
 }

--- a/llama-burn/src/tokenizer/sentence_piece.rs
+++ b/llama-burn/src/tokenizer/sentence_piece.rs
@@ -51,4 +51,8 @@ impl Tokenizer for SentiencePieceTokenizer {
     fn eos_id(&self) -> u32 {
         self.eos_token_id
     }
+
+    fn stop_ids(&self) -> Vec<u32> {
+        vec![self.eos_id()]
+    }
 }

--- a/llama-burn/src/tokenizer/tiktoken.rs
+++ b/llama-burn/src/tokenizer/tiktoken.rs
@@ -11,6 +11,7 @@ use super::Tokenizer;
 
 const BOS_TOKEN: &str = "<|begin_of_text|>";
 const EOS_TOKEN: &str = "<|end_of_text|>";
+const EOT_TOKEN: &str = "<|eot_id|>";
 
 const NUM_RESERVED_SPECIAL_TOKENS: usize = 256;
 const SPECIAL_TOKENS: [&str; 10] = [
@@ -23,7 +24,7 @@ const SPECIAL_TOKENS: [&str; 10] = [
     "<|start_header_id|>",
     "<|end_header_id|>",
     "<|reserved_special_token_4|>",
-    "<|eot_id|>", // end of turn
+    EOT_TOKEN, // end of turn
 ];
 const PATTERN: &str = r#"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"#;
 
@@ -32,6 +33,7 @@ pub struct Tiktoken {
     bpe: CoreBPE,
     bos_token_id: usize,
     eos_token_id: usize,
+    eot_token_id: usize,
 }
 
 impl Tokenizer for Tiktoken {
@@ -74,6 +76,7 @@ impl Tokenizer for Tiktoken {
 
         let bos_token_id = special_tokens[BOS_TOKEN];
         let eos_token_id = special_tokens[EOS_TOKEN];
+        let eot_token_id = special_tokens[EOT_TOKEN];
 
         let bpe =
             CoreBPE::new(mergeable_ranks, special_tokens, PATTERN).map_err(|e| e.to_string())?;
@@ -81,6 +84,7 @@ impl Tokenizer for Tiktoken {
             bpe,
             bos_token_id,
             eos_token_id,
+            eot_token_id,
         })
     }
 
@@ -109,5 +113,9 @@ impl Tokenizer for Tiktoken {
 
     fn eos_id(&self) -> u32 {
         self.eos_token_id as u32
+    }
+
+    fn stop_ids(&self) -> Vec<u32> {
+        vec![self.eos_id(), self.eot_token_id as u32]
     }
 }

--- a/llama-burn/src/tokenizer/tiktoken.rs
+++ b/llama-burn/src/tokenizer/tiktoken.rs
@@ -12,19 +12,21 @@ use super::Tokenizer;
 const BOS_TOKEN: &str = "<|begin_of_text|>";
 const EOS_TOKEN: &str = "<|end_of_text|>";
 const EOT_TOKEN: &str = "<|eot_id|>";
+const EOM_TOKEN: &str = "<|eom_id|>";
 
 const NUM_RESERVED_SPECIAL_TOKENS: usize = 256;
-const SPECIAL_TOKENS: [&str; 10] = [
+const SPECIAL_TOKENS: [&str; 11] = [
     BOS_TOKEN,
     EOS_TOKEN,
     "<|reserved_special_token_0|>",
     "<|reserved_special_token_1|>",
-    "<|reserved_special_token_2|>",
-    "<|reserved_special_token_3|>",
+    "<|finetune_right_pad_id|>",
+    "<|step_id|>",
     "<|start_header_id|>",
     "<|end_header_id|>",
-    "<|reserved_special_token_4|>",
+    EOM_TOKEN, // end of message
     EOT_TOKEN, // end of turn
+    "<|python_tag|>",
 ];
 const PATTERN: &str = r#"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"#;
 
@@ -34,6 +36,7 @@ pub struct Tiktoken {
     bos_token_id: usize,
     eos_token_id: usize,
     eot_token_id: usize,
+    eom_token_id: usize,
 }
 
 impl Tokenizer for Tiktoken {
@@ -62,9 +65,9 @@ impl Tokenizer for Tiktoken {
                 .iter()
                 .map(|t| t.to_string())
                 .collect::<Vec<_>>(),
-            (5..NUM_RESERVED_SPECIAL_TOKENS - 5)
+            (0..NUM_RESERVED_SPECIAL_TOKENS - SPECIAL_TOKENS.len())
                 .into_iter()
-                .map(|i| format!("<|reserved_special_token_{i}|>"))
+                .map(|i| format!("<|reserved_special_token_{}|>", i + 2))
                 .collect::<Vec<_>>(),
         ]
         .concat();
@@ -77,6 +80,7 @@ impl Tokenizer for Tiktoken {
         let bos_token_id = special_tokens[BOS_TOKEN];
         let eos_token_id = special_tokens[EOS_TOKEN];
         let eot_token_id = special_tokens[EOT_TOKEN];
+        let eom_token_id = special_tokens[EOM_TOKEN];
 
         let bpe =
             CoreBPE::new(mergeable_ranks, special_tokens, PATTERN).map_err(|e| e.to_string())?;
@@ -85,6 +89,7 @@ impl Tokenizer for Tiktoken {
             bos_token_id,
             eos_token_id,
             eot_token_id,
+            eom_token_id,
         })
     }
 
@@ -116,6 +121,10 @@ impl Tokenizer for Tiktoken {
     }
 
     fn stop_ids(&self) -> Vec<u32> {
-        vec![self.eos_id(), self.eot_token_id as u32]
+        vec![
+            self.eos_id(),
+            self.eom_token_id as u32,
+            self.eot_token_id as u32,
+        ]
     }
 }

--- a/llama-burn/src/tokenizer/tiktoken.rs
+++ b/llama-burn/src/tokenizer/tiktoken.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     fs::File,
     io::{BufRead, BufReader},
 };
@@ -89,8 +88,7 @@ impl Tokenizer for Tiktoken {
         let bos_token = if bos { vec![self.bos_token_id] } else { vec![] };
         let eos_token = if eos { vec![self.eos_token_id] } else { vec![] };
 
-        // `allowed_special` is an empty set
-        let tokens = self.bpe.encode(text, HashSet::new());
+        let tokens = self.bpe.encode_with_special_tokens(text);
 
         [bos_token, tokens, eos_token]
             .into_iter()


### PR DESCRIPTION
Ported the new Llama weights to our implementation along with their custom RoPE frequency scaling.

Made a couple additional changes to fix minor things along the way:
- Changed the default llama3 model for the chat example to use 3.1
  - Added command line argument to select between the versions
- Added multiple stop tokens condition to properly support end of turn + end of text for newer llama models
- Fixed the `max_seq_len` to be properly propagated to (command argument value was not used before)
- Added `import` feature flag to keep pytorch weights loading code optional

TODO:
- [x] Use Burn version 0.14