### PR TITLE
Add CRAFT text detection to community models

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Explore the curated list of models developed by the community ♥.
 | kord (music note predictor)                      | A music theory model that can detect notes in short audio clips.  | [twitchax/kord](https://github.com/twitchax/kord)                                 |
 | Whisper-Live                                     | A fork of [Gadersd/whisper-burn](https://github.com/Gadersd/whisper-burn) which has been updated for Burn 13 and provides live transcription | [sudomonikers/whisper-burn](https://github.com/sudomonikers/whisper-burn) |
 | [Inception V3](https://arxiv.org/abs/1512.00567) | A CNN used for calculating FID scores.                            | [varonroy/inception-v3-burn](https://github.com/varonroy/inception-v3-burn/)      |
+| [CRAFT](https://arxiv.org/abs/1904.01941)        | A CNN for character-region aware text detection                   | [wingertge/craft-burn](https://github.com/wingertge/craft-burn) |
 
 ## License Information
 


### PR DESCRIPTION
Updated README

Added a link to the CRAFT text detection model: [wingertge/craft-burn](https://github.com/wingertge/craft-burn).
The repository specifies the license for both the model and the weights as noted in the README.
The model also includes the required pre postprocessing image ops until they can get added to `burn`.