### PR TITLE
Llama 3.2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        rust: [stable, 1.75.0]
+        rust: [stable, 1.82.0]
 
     steps:
       - uses: actions/checkout@v4

--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -23,7 +23,7 @@ wgpu = ["burn/wgpu"]
 import = ["burn-import"]
 
 [dependencies]
-burn = { version = "0.16.0", default-features = false, features = ["std"] }
+burn = { version = "0.16.0", default-features = false, features = ["std", "fusion"] }
 burn-import = { version = "0.16.0", optional = true }
 cubecl-runtime = { version = "0.4.0", features = ["channel-mpsc"] } # missing feature flag
 
@@ -56,6 +56,6 @@ clap = { version = "4.5.4", features = ["derive"] }
 
 # Until burn 0.16.0 is released we use a compatible git revision
 [patch.crates-io]
-burn = { git = "https://github.com/tracel-ai/burn", rev = "2338912dafb7f9f18c8d14b851f7c7fd6ec542c7" }
-burn-import = { git = "https://github.com/tracel-ai/burn", rev = "2338912dafb7f9f18c8d14b851f7c7fd6ec542c7" }
-cubecl-runtime = { git = "https://github.com/tracel-ai/cubecl", rev = "4372c4109ec36b368236ad895df5009f6b6f1a18" }
+burn = { git = "https://github.com/tracel-ai/burn", rev = "da8de562b0f67869c8a8c629b8535f938fd317f9" }
+burn-import = { git = "https://github.com/tracel-ai/burn", rev = "da8de562b0f67869c8a8c629b8535f938fd317f9" }
+cubecl-runtime = { git = "https://github.com/tracel-ai/cubecl", rev = "5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d" }

--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -25,6 +25,8 @@ import = ["burn-import"]
 [dependencies]
 burn = { version = "0.16.0", default-features = false, features = ["std"] }
 burn-import = { version = "0.16.0", optional = true }
+cubecl-runtime = { version = "0.4.0", features = ["channel-mpsc"] } # missing feature flag
+
 itertools = { version = "0.12.1", default-features = false, features = [
     "use_alloc",
 ] }
@@ -56,3 +58,4 @@ clap = { version = "4.5.4", features = ["derive"] }
 [patch.crates-io]
 burn = { git = "https://github.com/tracel-ai/burn", rev = "2338912dafb7f9f18c8d14b851f7c7fd6ec542c7" }
 burn-import = { git = "https://github.com/tracel-ai/burn", rev = "2338912dafb7f9f18c8d14b851f7c7fd6ec542c7" }
+cubecl-runtime = { git = "https://github.com/tracel-ai/cubecl", rev = "4372c4109ec36b368236ad895df5009f6b6f1a18" }

--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -25,7 +25,6 @@ import = ["burn-import"]
 [dependencies]
 burn = { version = "0.16.0", default-features = false, features = ["std", "fusion"] }
 burn-import = { version = "0.16.0", optional = true }
-cubecl-runtime = { version = "0.4.0", features = ["channel-mpsc"] } # missing feature flag
 
 itertools = { version = "0.12.1", default-features = false, features = [
     "use_alloc",
@@ -53,9 +52,3 @@ rand = { version = "0.8.5", default-features = false, features = [
 [dev-dependencies]
 burn = { version = "0.16.0", default-features = false }
 clap = { version = "4.5.4", features = ["derive"] }
-
-# Until burn 0.16.0 is released we use a compatible git revision
-[patch.crates-io]
-burn = { git = "https://github.com/tracel-ai/burn", rev = "da8de562b0f67869c8a8c629b8535f938fd317f9" }
-burn-import = { git = "https://github.com/tracel-ai/burn", rev = "da8de562b0f67869c8a8c629b8535f938fd317f9" }
-cubecl-runtime = { git = "https://github.com/tracel-ai/cubecl", rev = "5a3f9ac9f6178c4f76570535bf5e42ef12a19a3d" }

--- a/llama-burn/Cargo.toml
+++ b/llama-burn/Cargo.toml
@@ -23,8 +23,8 @@ wgpu = ["burn/wgpu"]
 import = ["burn-import"]
 
 [dependencies]
-burn = { version = "0.14.0", default-features = false, features = ["std"] }
-burn-import = { version = "0.14.0", optional = true }
+burn = { version = "0.16.0", default-features = false, features = ["std"] }
+burn-import = { version = "0.16.0", optional = true }
 itertools = { version = "0.12.1", default-features = false, features = [
     "use_alloc",
 ] }
@@ -49,5 +49,10 @@ rand = { version = "0.8.5", default-features = false, features = [
 ] } # std_rng is for no_std
 
 [dev-dependencies]
-burn = { version = "0.14.0", default-features = false }
+burn = { version = "0.16.0", default-features = false }
 clap = { version = "4.5.4", features = ["derive"] }
+
+# Until burn 0.16.0 is released we use a compatible git revision
+[patch.crates-io]
+burn = { git = "https://github.com/tracel-ai/burn", rev = "2338912dafb7f9f18c8d14b851f7c7fd6ec542c7" }
+burn-import = { git = "https://github.com/tracel-ai/burn", rev = "2338912dafb7f9f18c8d14b851f7c7fd6ec542c7" }

--- a/llama-burn/NOTICES.md
+++ b/llama-burn/NOTICES.md
@@ -10,6 +10,8 @@ The model implementation was adapted from the original
 [Meta Llama 3 Community License Agreement](https://github.com/meta-llama/llama3/blob/main/LICENSE).
 The Llama 3.1 model is distributed under the
 [Llama 3.1 Community License Agreement](https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/LICENSE).
+The Llama 3.2 model is distributed under the
+[Llama 3.2 Community License Agreement](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/LICENSE).
 
 The TinyLlama implementation is derived from the same code, but its weights and tokenizers were
 adapted from the [original implementation](https://github.com/jzhang38/TinyLlama) distributed under

--- a/llama-burn/README.md
+++ b/llama-burn/README.md
@@ -4,8 +4,8 @@
 
 The popular Llama LLM is here!
 
-This repository contains the [Llama 3.1](https://github.com/meta-llama/llama-models/),
-[Llama 3](https://github.com/meta-llama/llama3) and
+This repository contains the
+[Llama 3.2, Llama 3.1, Llama 3](https://github.com/meta-llama/llama-models/), and
 [TinyLlama](https://github.com/jzhang38/TinyLlama) implementations with their corresponding
 tokenizers. You can find the [Burn](https://github.com/tracel-ai/burn) implementation for the Llama
 variants in [src/llama.rs](src/llama.rs).
@@ -89,8 +89,10 @@ cargo run --release --features llama3,cuda --example chat
 ```
 
 **Built with Meta Llama 3.** This example uses the
-[Meta-Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct) (default)
-and [Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)
+[Meta-Llama-3.2-1B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct) (default),
+[Meta-Llama-3.2-3B-Instruct](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct),
+[Meta-Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct) and
+[Meta-Llama-3-8B-Instruct](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct)
 instruction-tuned models. Note that the [base pre-trained Llama-3 model](./src/pretrained.rs#L77) is
 also available if you wish to use it in your application.
 

--- a/llama-burn/examples/chat.rs
+++ b/llama-burn/examples/chat.rs
@@ -42,7 +42,7 @@ pub struct Config {
 
     /// The Llama 3 model version.
     #[cfg(feature = "llama3")]
-    #[arg(long, default_value = "llama-3.2-3b-instruct")]
+    #[arg(long, default_value = "llama-3.2-1b-instruct")]
     model_version: Llama3,
 }
 

--- a/llama-burn/examples/chat.rs
+++ b/llama-burn/examples/chat.rs
@@ -198,13 +198,15 @@ mod wgpu {
 #[cfg(feature = "cuda")]
 mod cuda {
     use super::*;
-    use burn::backend::{cuda_jit::CudaDevice, CudaJit};
+    use burn::{
+        backend::{cuda_jit::CudaDevice, CudaJit},
+        tensor::f16,
+    };
 
     pub fn run(args: Config) {
         let device = CudaDevice::default();
 
-        // NOTE: compilation errors in f16
-        chat::<CudaJit<f32, i32>>(args, device);
+        chat::<CudaJit<f16, i32>>(args, device);
     }
 }
 

--- a/llama-burn/examples/chat.rs
+++ b/llama-burn/examples/chat.rs
@@ -42,7 +42,7 @@ pub struct Config {
 
     /// The Llama 3 model version.
     #[cfg(feature = "llama3")]
-    #[arg(long, default_value = "llama-3.1-8b-instruct")]
+    #[arg(long, default_value = "llama-3.2-3b-instruct")]
     model_version: Llama3,
 }
 
@@ -56,6 +56,12 @@ enum Llama3 {
     /// Llama-3.1-8B-Instruct.
     #[value(name = "llama-3.1-8b-instruct")]
     V31Instruct,
+    /// Llama-3.2-1B-Instruct.
+    #[value(name = "llama-3.2-1b-instruct")]
+    V321bInstruct,
+    /// Llama-3.2-3B-Instruct.
+    #[value(name = "llama-3.2-3b-instruct")]
+    V323bInstruct,
 }
 
 pub fn generate<B: Backend, T: Tokenizer>(
@@ -122,6 +128,12 @@ pub fn chat<B: Backend>(args: Config, device: Device<B>) {
             }
             Llama3::V31Instruct => {
                 LlamaConfig::llama3_1_8b_pretrained::<B>(args.max_seq_len, &device).unwrap()
+            }
+            Llama3::V321bInstruct => {
+                LlamaConfig::llama3_2_1b_pretrained::<B>(args.max_seq_len, &device).unwrap()
+            }
+            Llama3::V323bInstruct => {
+                LlamaConfig::llama3_2_3b_pretrained::<B>(args.max_seq_len, &device).unwrap()
             }
         };
         println!("Processing prompt: {}", prompt);

--- a/llama-burn/src/cache.rs
+++ b/llama-burn/src/cache.rs
@@ -1,71 +1,72 @@
-use burn::tensor::{backend::Backend, Tensor};
-
-// Adapted from `burn::nn::cache`
-enum CacheState<T> {
-    Value(T),
-    Empty,
-}
-
-/// A cache for a tensor.
-struct TensorCache<B: Backend, const D: usize> {
-    state: CacheState<Tensor<B, D>>,
-}
-
-impl<B: Backend, const D: usize> TensorCache<B, D> {
-    /// Creates a new empty cache.
-    ///
-    /// # Returns
-    ///
-    /// The empty cache.
-    pub fn empty() -> Self {
-        Self {
-            state: CacheState::Empty,
-        }
-    }
-}
+use burn::tensor::{backend::Backend, Device, Tensor};
 
 pub(crate) struct AutoregressiveCache<B: Backend> {
-    /// Tensor cache with shape `[max_batch_size, num_heads, seq_len, head_dim]`
-    cache: TensorCache<B, 4>,
+    /// Tensor cache with shape `[batch_size, num_heads, seq_len, d_model]`
+    cache: Tensor<B, 4>,
     pub(crate) max_seq_len: usize,
+    cur_seq_len: usize,
 }
 
 impl<B: Backend> AutoregressiveCache<B> {
     /// Creates a new empty cache.
-    pub fn new(max_seq_len: usize) -> Self {
+    pub fn new(
+        max_batch_size: usize,
+        num_heads: usize,
+        max_seq_len: usize,
+        d_model: usize,
+        device: &Device<B>,
+    ) -> Self {
         Self {
-            cache: TensorCache::empty(),
+            cache: Tensor::empty([max_batch_size, num_heads, max_seq_len, d_model], device),
             max_seq_len,
+            cur_seq_len: 0,
         }
     }
 
+    /// Reset the cache state.
+    pub fn reset(&mut self) {
+        self.cache = Tensor::empty(self.cache.shape(), &self.cache.device());
+        self.cur_seq_len = 0;
+    }
+
     pub fn forward(&mut self, tensor: Tensor<B, 4>) -> Tensor<B, 4> {
-        let mut tensor_old = CacheState::Empty;
-        core::mem::swap(&mut self.cache.state, &mut tensor_old);
+        let [batch_size, num_heads, seq_len, d_model] = tensor.dims();
+        let mut new_seq_len = self.cur_seq_len + seq_len;
 
-        let tensor_new = match tensor_old {
-            CacheState::Value(tensor_old) => {
-                let mut tensor_new = Tensor::cat(vec![tensor_old, tensor], 2);
+        if new_seq_len > self.max_seq_len {
+            self.cur_seq_len = self.max_seq_len - seq_len;
+            let prev_slice = self.cache.clone().slice([
+                0..batch_size,
+                0..num_heads,
+                seq_len..self.max_seq_len,
+                0..d_model,
+            ]);
+            self.cache = self.cache.clone().slice_assign(
+                [0..batch_size, 0..num_heads, 0..self.cur_seq_len, 0..d_model],
+                prev_slice,
+            );
+            new_seq_len = self.max_seq_len;
+        }
 
-                // Limit to context length (aka max sequence length)
-                let seq_len = tensor_new.dims()[2];
-                if seq_len > self.max_seq_len {
-                    tensor_new = tensor_new.narrow(2, seq_len - self.max_seq_len, self.max_seq_len);
-                }
-                tensor_new
-            }
-            _ => tensor,
-        };
+        self.cache = self.cache.clone().slice_assign(
+            [
+                0..batch_size,
+                0..num_heads,
+                self.cur_seq_len..new_seq_len,
+                0..d_model,
+            ],
+            tensor,
+        );
 
-        self.cache.state = CacheState::Value(tensor_new.clone());
-        tensor_new
+        self.cur_seq_len += seq_len;
+
+        self.cache
+            .clone()
+            .slice([0..batch_size, 0..num_heads, 0..self.cur_seq_len, 0..d_model])
     }
 
     /// Returns the cached sequence length.
     pub fn len(&self) -> usize {
-        match &self.cache.state {
-            CacheState::Empty => 0,
-            CacheState::Value(t) => t.dims()[2],
-        }
+        self.cur_seq_len
     }
 }

--- a/llama-burn/src/lib.rs
+++ b/llama-burn/src/lib.rs
@@ -4,3 +4,20 @@ pub mod pretrained;
 pub mod sampling;
 pub mod tokenizer;
 mod transformer;
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "cuda")]
+    use burn::{backend::CudaJit, tensor::f16};
+    #[cfg(feature = "cuda")]
+    pub type TestBackend = CudaJit<f16, i32>;
+
+    // NOTE: no tests on tch cpu (f32)
+    #[cfg(feature = "tch-gpu")]
+    use burn::{backend::LibTorch, tensor::f16};
+    #[cfg(feature = "tch-gpu")]
+    pub type TestBackend = LibTorch<f16>;
+
+    #[cfg(any(feature = "cuda", feature = "tch-gpu"))]
+    pub type TestTensor<const D: usize> = burn::tensor::Tensor<TestBackend, D>;
+}

--- a/llama-burn/src/llama.rs
+++ b/llama-burn/src/llama.rs
@@ -87,6 +87,7 @@ impl LlamaConfig {
     pub fn llama3_2_3b(tokenizer_path: &str) -> Self {
         // hidden_size = 8192; vocab_size = 128256
         Self::new(8192, 128256, tokenizer_path.to_string())
+            .with_d_model(3072)
             .with_num_hidden_layers(28)
             .with_num_attention_heads(24)
             .with_num_key_value_heads(Some(8))
@@ -100,6 +101,7 @@ impl LlamaConfig {
     pub fn llama3_2_1b(tokenizer_path: &str) -> Self {
         // hidden_size = 8192; vocab_size = 128256
         Self::new(8192, 128256, tokenizer_path.to_string())
+            .with_d_model(2048)
             .with_num_hidden_layers(16)
             .with_num_key_value_heads(Some(8))
             .with_rope(

--- a/llama-burn/src/pretrained.rs
+++ b/llama-burn/src/pretrained.rs
@@ -71,7 +71,7 @@ pub enum Llama {
     Llama31Instruct,
     /// Llama-3.2-3B-Instruct.
     Llama323bInstruct,
-    /// Llama-3.1-3B-Instruct.
+    /// Llama-3.2-1B-Instruct.
     Llama321bInstruct,
     /// TinyLlama-1.1B Chat v1.0.
     TinyLlama,

--- a/llama-burn/src/pretrained.rs
+++ b/llama-burn/src/pretrained.rs
@@ -69,6 +69,10 @@ pub enum Llama {
     Llama3Instruct,
     /// Llama-3.1-8B-Instruct.
     Llama31Instruct,
+    /// Llama-3.2-3B-Instruct.
+    Llama323bInstruct,
+    /// Llama-3.1-3B-Instruct.
+    Llama321bInstruct,
     /// TinyLlama-1.1B Chat v1.0.
     TinyLlama,
 }
@@ -90,6 +94,16 @@ impl ModelMeta for Llama {
                 name: "Llama-3.1-8B-Instruct",
                 model: "https://huggingface.co/tracel-ai/llama-3.1-8b-instruct-burn/resolve/main/model.mpk?download=true",
                 tokenizer: "https://huggingface.co/tracel-ai/llama-3.1-8b-instruct-burn/resolve/main/tokenizer.model?download=true",
+            },
+            Self::Llama323bInstruct => Pretrained {
+                name: "Llama-3.2-3B-Instruct",
+                model: "https://huggingface.co/tracel-ai/llama-3.2-3b-instruct-burn/resolve/main/model.mpk?download=true",
+                tokenizer: "https://huggingface.co/tracel-ai/llama-3.2-3b-instruct-burn/resolve/main/tokenizer.model?download=true",
+            },
+            Self::Llama321bInstruct => Pretrained {
+                name: "Llama-3.2-1B-Instruct",
+                model: "https://huggingface.co/tracel-ai/llama-3.2-1b-instruct-burn/resolve/main/model.mpk?download=true",
+                tokenizer: "https://huggingface.co/tracel-ai/llama-3.2-1b-instruct-burn/resolve/main/tokenizer.model?download=true",
             },
             Self::TinyLlama => Pretrained {
                 name: "TinyLlama-1.1B",

--- a/llama-burn/src/transformer.rs
+++ b/llama-burn/src/transformer.rs
@@ -72,6 +72,7 @@ pub struct Transformer<B: Backend> {
     tok_embeddings: Embedding<B>,
     layers: Vec<TransformerBlock<B>>,
     norm: RmsNorm<B>,
+    // NOTE: Starting with Llama 3.2, the weights of the output layer are tied with the embedding
     output: Linear<B>,
 }
 

--- a/llama-burn/src/transformer.rs
+++ b/llama-burn/src/transformer.rs
@@ -392,3 +392,31 @@ impl<B: Backend> MultiHeadAttention<B> {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg(any(feature = "cuda", feature = "tch-gpu"))]
+mod tests {
+    use super::*;
+    use crate::tests::*;
+
+    use burn::tensor::TensorData;
+
+    #[test]
+    fn test_rms_norm() {
+        let device = Default::default();
+
+        let rms = RmsNormConfig::new(4).with_epsilon(1e-5).init(&device);
+        let input = TestTensor::<3>::from([[
+            [0.0025997162, 0.0030002594, -0.006000519, 0.006000519],
+            [0.0010004044, 0.00080013275, 0.0015001297, -0.01600647],
+        ]]);
+
+        let output = rms.forward(input);
+        let expected = TensorData::from([[
+            [0.45996094, 0.5307617, -1.0615234, 1.0615234],
+            [0.11553955, 0.09240723, 0.17321777, -1.8486328],
+        ]]);
+
+        output.into_data().assert_approx_eq(&expected, 3);
+    }
+}

--- a/llama-burn/src/transformer.rs
+++ b/llama-burn/src/transformer.rs
@@ -213,10 +213,22 @@ pub struct KeyValueCache<B: Backend> {
 
 impl<B: Backend> KeyValueCache<B> {
     /// Create a new [key-value cache](KeyValueCache).
-    pub fn new(max_seq_len: usize) -> Self {
+    pub fn new(
+        max_batch_size: usize,
+        num_heads: usize,
+        max_seq_len: usize,
+        d_model: usize,
+        device: &Device<B>,
+    ) -> Self {
         Self {
-            key: AutoregressiveCache::new(max_seq_len),
-            value: AutoregressiveCache::new(max_seq_len),
+            key: AutoregressiveCache::new(max_batch_size, num_heads, max_seq_len, d_model, device),
+            value: AutoregressiveCache::new(
+                max_batch_size,
+                num_heads,
+                max_seq_len,
+                d_model,
+                device,
+            ),
         }
     }
 
@@ -241,8 +253,8 @@ impl<B: Backend> KeyValueCache<B> {
     /// Use between different contexts (i.e., for each new prompt).
     #[allow(dead_code)]
     pub fn reset(&mut self) {
-        self.key = AutoregressiveCache::new(self.key.max_seq_len);
-        self.value = AutoregressiveCache::new(self.value.max_seq_len);
+        self.key.reset();
+        self.value.reset();
     }
 }
 


### PR DESCRIPTION
Added Llama 3.2 1b and 3b instruct models (text only).

- New model configs & weights (uploaded to HF hub)
  - Refactored RoPE frequency scaling to add config (3.1 and 3.2 use different params)
- Updated burn dependencies
- Switched cuda backend example to use f16 (fixed since 0.15)

Closes #46