### PR TITLE
Fixing build error for resnet example

### DIFF
--- a/resnet-burn/examples/finetune/examples/finetune.rs
+++ b/resnet-burn/examples/finetune/examples/finetune.rs
@@ -26,10 +26,7 @@ mod tch_gpu {
 
 #[cfg(feature = "wgpu")]
 mod wgpu {
-    use burn::{
-        backend::wgpu::{Wgpu, WgpuDevice},
-        Wgpu,
-    };
+    use burn::backend::wgpu::{Wgpu, WgpuDevice};
 
     pub fn run() {
         super::run::<Wgpu>(WgpuDevice::default());


### PR DESCRIPTION
Fixes this build error:


```
/home/linux/burn-dev/models/resnet-burn$ cargo build --release --example finetune --features wgpu
   Compiling resnet-burn v0.1.0 (/home/linux/burn-dev/models/resnet-burn/resnet)
   Compiling finetune v0.2.0 (/home/linux/burn-dev/models/resnet-burn/examples/finetune)
error[E0432]: unresolved import `burn::Wgpu`
  --> examples/finetune/examples/finetune.rs:31:9
   |
31 |         Wgpu,
   |         ^^^^ no `Wgpu` in the root
   |
   = help: consider importing this type alias instead:
           burn::backend::Wgpu

For more information about this error, try `rustc --explain E0432`.
error: could not compile `finetune` (example "finetune") due to 1 previous error
```
