### PR TITLE
Add wav2vec-burn community model

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Explore the curated list of models developed by the community ♥.
 | [SSD]                 | Object detection           | [catch-twenty-two/rust-ssd]            |
 | [DeepSeek-OCR-2]      | OCR inference              | [huahuadeliaoliao/DeepSeek-OCR-2-burn] |
 | SpeechAligner         | Speech model training      | [dnvt/burn-speech-training]            |
+| [Wav2Vec 2.0]         | Speech recognition         | [privacyresearchgroup/wav2vec-burn]    |
 
 ## License Information
 
@@ -71,6 +72,7 @@ respective repositories for specific license information.
 [RWKV v7]: https://arxiv.org/abs/2503.14456
 [SSD]: https://arxiv.org/abs/1512.02325
 [DeepSeek-OCR-2]: https://huggingface.co/deepseek-ai/DeepSeek-OCR-2
+[Wav2Vec 2.0]: https://arxiv.org/abs/2006.11477
 
 <!-- Community Repositories -->
 
@@ -85,3 +87,4 @@ respective repositories for specific license information.
 [catch-twenty-two/rust-ssd]: https://github.com/catch-twenty-two/rust-ssd
 [huahuadeliaoliao/DeepSeek-OCR-2-burn]: https://github.com/huahuadeliaoliao/DeepSeek-OCR-2-burn
 [dnvt/burn-speech-training]: https://github.com/dnvt/burn-speech-training
+[privacyresearchgroup/wav2vec-burn]: https://github.com/privacyresearchgroup/wav2vec-burn


### PR DESCRIPTION
I'd like to add my project [privacyresearchgroup/wav2vec-burn](https://github.com/privacyresearchgroup/wav2vec-burn) to the community contributions table.

It's intended to be a readable implementation of wav2vec 2.0, currently only for study purposes, but we might use it in production in the future at [Signal](https://github.com/signalapp) at some point. It currently only supports the `base` and `large` variants of wav2vec.

I'm actively working on this project, so more documentation, testing, and support for more variants will come soon. Support for fine-tuning after that.

The tests currently seem to trigger independent, unrelated bugs in both the `ndarray` and `cpu` backends. I'll file issues once I figure out the causes.
